### PR TITLE
Setting externals file extension, check for ANDROID platform before Linux

### DIFF
--- a/pure-data/src/s_loader.c
+++ b/pure-data/src/s_loader.c
@@ -38,6 +38,8 @@ a fat binary or an indication of the instruction set. */
 
 #ifdef __FreeBSD__
 static char sys_dllextent[] = ".b_i386", sys_dllextent2[] = ".pd_freebsd";
+#elif defined( ANDROID )
+static char sys_dllextent[] = ".l_arm", sys_dllextent2[] = ".pd_linux";
 #elif defined(__linux__) || defined(__FreeBSD_kernel__) || defined(__GNU__)
 # ifdef __x86_64__
 static char sys_dllextent[] = ".l_ia64", sys_dllextent2[] = ".pd_linux";
@@ -52,8 +54,6 @@ static char sys_dllextent[] = ".d_ppc", sys_dllextent2[] = ".pd_darwin";
 # endif
 #elif defined(_WIN32) || defined(__CYGWIN__)
 static char sys_dllextent[] = ".m_i386", sys_dllextent2[] = ".dll";
-#elif defined(ANDROID)
-static char sys_dllextent[] = ".l_arm", sys_dllextent2[] = ".pd_linux";
 #endif
 
     /* maintain list of loaded modules to avoid repeating loads */


### PR DESCRIPTION
The Android GCC toolchain #defines **linux**, so the Android specific branch was never being hit. Moving the check above Linux fixes it.

Should probably add a check for **arm** vs x86 architecture too, but I haven't been able to find documentation of the architecture macros.
