### PR TITLE
Fixing a few compiler warnings on OS X

### DIFF
--- a/pure-data/src/d_filter.c
+++ b/pure-data/src/d_filter.c
@@ -493,7 +493,7 @@ static t_int *sigsamphold_perform(t_int *w)
     int i;
     t_sample lastin = x->x_lastin;
     t_sample lastout = x->x_lastout;
-    for (i = 0; i < n; i++, *in1++)
+    for (i = 0; i < n; i++, in1++)
     {
         t_sample next = *in2++;
         if (next < lastin) lastout = *in1;

--- a/pure-data/src/d_math.c
+++ b/pure-data/src/d_math.c
@@ -341,7 +341,7 @@ static t_int *ftom_tilde_perform(t_int *w)
 {
     t_sample *in = *(t_sample **)(w+1), *out = *(t_sample **)(w+2);
     t_int n = *(t_int *)(w+3);
-    for (; n--; *in++, out++)
+    for (; n--; in++, out++)
     {
         t_sample f = *in;
         *out = (f > 0 ? 17.3123405046 * log(.12231220585 * f) : -1500);

--- a/pure-data/src/g_readwrite.c
+++ b/pure-data/src/g_readwrite.c
@@ -44,7 +44,7 @@ int glist_readscalar(t_glist *x, int natoms, t_atom *vec,
 static void canvas_readerror(int natoms, t_atom *vec, int message, 
     int nline, char *s)
 {
-    error(s);
+    error("%s", s);
     startpost("line was:");
     postatom(nline, vec + message);
     endpost();


### PR DESCRIPTION
A few very minor changes.

A couple of these fix pointer dereferencing which was subsequently not used (has no effect other than causing a warning with the LLVM compiler on OS X).  The only important part is the advancing (++) of the pointers.  In the other case, an error() function with variable arguments was being printed using an uncontrolled format string (http://en.wikipedia.org/wiki/Uncontrolled_format_string). In the context of the actual code, I don't think it was a safety issue -- but it does get rid of another compiler warning/error with the latest LLVM compiler.

This is my first (admittedly very minor) pull request, I hope it's okay.  The changes (if accepted) could also presumably be merged into the original pure_data repository at some point.
