### PR TITLE
Better support for loading externals on Android

### DIFF
--- a/Android.mk
+++ b/Android.mk
@@ -57,7 +57,7 @@ include $(BUILD_SHARED_LIBRARY)
 
 include $(CLEAR_VARS)
 
-LOCAL_MODULE := bonk~
+LOCAL_MODULE := bonk_tilde
 LOCAL_C_INCLUDES := $(LOCAL_PATH)/pure-data/src
 LOCAL_CFLAGS := -DPD
 LOCAL_SRC_FILES := pure-data/extra/bonk~/bonk~.c
@@ -70,7 +70,7 @@ include $(BUILD_SHARED_LIBRARY)
 
 include $(CLEAR_VARS)
 
-LOCAL_MODULE := lrshift~
+LOCAL_MODULE := lrshift_tilde
 LOCAL_C_INCLUDES := $(LOCAL_PATH)/pure-data/src
 LOCAL_CFLAGS := -DPD
 LOCAL_SRC_FILES := pure-data/extra/lrshift~/lrshift~.c
@@ -83,7 +83,7 @@ include $(BUILD_SHARED_LIBRARY)
 
 include $(CLEAR_VARS)
 
-LOCAL_MODULE := fiddle~
+LOCAL_MODULE := fiddle_tilde
 LOCAL_C_INCLUDES := $(LOCAL_PATH)/pure-data/src
 LOCAL_CFLAGS := -DPD
 LOCAL_SRC_FILES := pure-data/extra/fiddle~/fiddle~.c
@@ -96,7 +96,7 @@ include $(BUILD_SHARED_LIBRARY)
 
 include $(CLEAR_VARS)
 
-LOCAL_MODULE := sigmund~
+LOCAL_MODULE := sigmund_tilde
 LOCAL_C_INCLUDES := $(LOCAL_PATH)/pure-data/src
 LOCAL_CFLAGS := -DPD
 LOCAL_SRC_FILES := pure-data/extra/sigmund~/sigmund~.c
@@ -122,7 +122,7 @@ include $(BUILD_SHARED_LIBRARY)
 
 include $(CLEAR_VARS)
 
-LOCAL_MODULE := loop~
+LOCAL_MODULE := loop_tilde
 LOCAL_C_INCLUDES := $(LOCAL_PATH)/pure-data/src
 LOCAL_CFLAGS := -DPD
 LOCAL_SRC_FILES := pure-data/extra/loop~/loop~.c


### PR DESCRIPTION
The Android build system imposes a few restrictions on shared libraries:
They need to start with "lib", end in ".so" and may not contain the ~
character. This enables loading of externals directly from the Android native lib
dir.
