### PR TITLE
Copy compiled file libpdcsharp.dll to csharp/bin/Debug folder

### DIFF
--- a/mingw_build.bat
+++ b/mingw_build.bat
@@ -4,3 +4,4 @@ SET MINGW32=C:\MinGW\mingw_32
 SET PATH=%MINGW32%\bin;%MINGW%\bin;%MSYS%\bin
 make clean
 make csharplib
+cp libs/libpdcsharp.dll csharp/bin/Debug/


### PR DESCRIPTION
Makes Building C# on Windows more comfortable.
