### PR TITLE
fixing a bug in PdDispatcher.m

### DIFF
--- a/objc/PdDispatcher.m
+++ b/objc/PdDispatcher.m
@@ -23,7 +23,7 @@
 }
 
 - (void)dealloc {
-    for (NSValue *handle in subscriptions) {
+    for (NSValue *handle in [subscriptions allValues]) {
         void *ptr = [handle pointerValue];
         [PdBase unsubscribe:ptr];
     }


### PR DESCRIPTION
this pull request fixes a bug in PdDispatcher.m
(fast enumeration of NSDictionary returns keys, not values)
