### PR TITLE
podspec (CocoaPods) file for iOS users

### DIFF
--- a/libpd.podspec
+++ b/libpd.podspec
@@ -1,0 +1,18 @@
+Pod::Spec.new do |s|
+  s.name         = "libpd"
+  s.version      = "0.0.1"
+
+  s.license      = { :type => 'Standard Improved BSD License', :file => 'License.txt' }
+
+  s.summary      = "libpd turns Pd into an embeddable library, so you can use Pd as a sound engine in mobile phone apps, games, web pages, and art projects."
+  s.homepage     = "https://github.com/libpd/libpd"
+  s.author       = { "name or nickname" => "email@address.com" }
+
+  s.source       = { :git => "https://github.com/libpd/libpd.git", :commit => "HEAD" }
+  s.source_files = 'cpp/**/*.{hpp,cpp}', 'libpd_wrapper/**/*.{h,c}', 'objc/**/*.{h,m}', 'pure-data/src/**/*.{h,c}'
+
+  s.ios.deployment_target = '4.0'
+
+  s.frameworks = 'Foundation'
+  s.compiler_flags = '-w -DPD -DUSEAPI_DUMMY -DHAVE_LIBDL -DHAVE_UNISTD_H'
+end


### PR DESCRIPTION
CocoaPods is a dependency management system for Objective-C projects.
This pull request contains a podspec file to allow iOS users (and perhaps OS X users too) to install and use libpd.

I have tested it with iOS 5.1 but not with OS X. I believe that it should work under OS X too, unless the compiler flags are different.

Notes:
- Authors -  I wasn't sure how to fill the "authors" field, so I left it empty. It can be easily modified to include libpd authors by following the instructions in [this link](http://docs.cocoapods.org/specification.html#authors).
- Version - was set to 0.0.1, as I wasn't sure if libpd has a version number.

To test it, follow the instructions ("Get started") in [cocoapods.org](http://cocoapods.org) and use the following as the Podfile:

```
platform :ios, '5.0'
pod 'libpd', :podspec => 'https://raw.github.com/kshahar/libpd/master/libpd.podspec'
```
