### PR TITLE
Added -DHAVE_ALLOCA_H flag to libpd-osx target

### DIFF
--- a/libpd.xcodeproj/project.pbxproj
+++ b/libpd.xcodeproj/project.pbxproj
@@ -823,6 +823,14 @@
 				GCC_PRECOMPILE_PREFIX_HEADER = YES;
 				GCC_PREFIX_HEADER = "";
 				INSTALL_PATH = /usr/local/lib;
+				OTHER_CFLAGS = (
+					"-DPD",
+					"-DUSEAPI_DUMMY",
+					"-DHAVE_LIBDL",
+					"-DHAVE_UNISTD_H",
+					"-DHAVE_ALLOCA_H",
+				);
+				OTHER_LDFLAGS = "-ObjC";
 				PRODUCT_NAME = "pd-osx";
 				SDKROOT = macosx;
 			};
@@ -839,6 +847,14 @@
 				GCC_PRECOMPILE_PREFIX_HEADER = YES;
 				GCC_PREFIX_HEADER = "";
 				INSTALL_PATH = /usr/local/lib;
+				OTHER_CFLAGS = (
+					"-DPD",
+					"-DUSEAPI_DUMMY",
+					"-DHAVE_LIBDL",
+					"-DHAVE_UNISTD_H",
+					"-DHAVE_ALLOCA_H",
+				);
+				OTHER_LDFLAGS = "-ObjC";
 				PRODUCT_NAME = "pd-osx";
 				SDKROOT = macosx;
 			};


### PR DESCRIPTION
Conflicts:
    libpd.xcodeproj/project.pbxproj

This is related to https://github.com/libpd/libpd/commit/e63874e444c2a8116c354a379204e6668a0ac835 and https://github.com/libpd/libpd/issues/57 The osx target needed the DHAVE_ALLOCA_H flag as well.
