### PR TITLE
fix for upcoming Pd-0.46 that has removed sched_tick() argument

### DIFF
--- a/libpd_wrapper/z_libpd.c
+++ b/libpd_wrapper/z_libpd.c
@@ -20,6 +20,15 @@
 #include "m_imp.h"
 #include "g_all_guis.h"
 
+#if PD_MINOR_VERSION < 46
+# define HAVE_SCHED_TICK_ARG
+#endif
+
+#ifdef HAVE_SCHED_TICK_ARG
+# define SCHED_TICK(x) sched_tick(x)
+#else
+# define SCHED_TICK(x) sched_tick()
+#endif
 void pd_init(void);
 
 static t_atom *argv = NULL, *curr;
@@ -52,7 +61,9 @@ int libpd_init(void) {
   sys_hipriority = 0;
   sys_nmidiin = 0;
   sys_nmidiout = 0;
+#ifdef HAVE_SCHED_TICK_ARG
   sys_time = 0;
+#endif
   pd_init();
   libpdreceive_setup();
   sys_set_audio_api(API_DUMMY);
@@ -107,7 +118,7 @@ int libpd_process_raw(const float *inBuffer, float *outBuffer) {
     *p++ = *inBuffer++;
   }
   memset(sys_soundout, 0, n_out * sizeof(t_sample));
-  sched_tick(sys_time + sys_time_per_dsp_tick);
+  SCHED_TICK(sys_time + sys_time_per_dsp_tick);
   for (p = sys_soundout, i = 0; i < n_out; i++) {
     *outBuffer++ = *p++;
   }
@@ -127,7 +138,7 @@ static const t_sample sample_to_short = SHRT_MAX,
       } \
     } \
     memset(sys_soundout, 0, sys_outchannels*DEFDACBLKSIZE*sizeof(t_sample)); \
-    sched_tick(sys_time + sys_time_per_dsp_tick); \
+    SCHED_TICK(sys_time + sys_time_per_dsp_tick); \
     for (j = 0, p0 = sys_soundout; j < DEFDACBLKSIZE; j++, p0++) { \
       for (k = 0, p1 = p0; k < sys_outchannels; k++, p1 += DEFDACBLKSIZE) { \
         *outBuffer++ = *p1 _y; \


### PR DESCRIPTION
in Pd-0.46, there is no more sys_time and sched_tick has it's argument removed
(as <<there's only one "reasonable" value to use anyhow>>").

this fix should allow to build libpd with both pd-0.45 and pd-0.46
