### PR TITLE
Fix compilation on OS X

### DIFF
--- a/libpd.xcodeproj/project.pbxproj
+++ b/libpd.xcodeproj/project.pbxproj
@@ -795,6 +795,13 @@
 				GCC_PRECOMPILE_PREFIX_HEADER = YES;
 				GCC_PREFIX_HEADER = "";
 				INSTALL_PATH = /usr/local/lib;
+				OTHER_CFLAGS = (
+					"-DPD",
+					"-DUSEAPI_DUMMY",
+					"-DHAVE_LIBDL",
+					"-DHAVE_UNISTD_H",
+					"-DHAVE_ALLOCA_H",
+				);
 				PRODUCT_NAME = "pd-osx";
 				SDKROOT = macosx;
 			};
@@ -811,6 +818,13 @@
 				GCC_PRECOMPILE_PREFIX_HEADER = YES;
 				GCC_PREFIX_HEADER = "";
 				INSTALL_PATH = /usr/local/lib;
+				OTHER_CFLAGS = (
+					"-DPD",
+					"-DUSEAPI_DUMMY",
+					"-DHAVE_LIBDL",
+					"-DHAVE_UNISTD_H",
+					"-DHAVE_ALLOCA_H",
+				);
 				PRODUCT_NAME = "pd-osx";
 				SDKROOT = macosx;
 			};


### PR DESCRIPTION
Linking on OS X, I was getting this error:

```
Undefined symbols for architecture x86_64:
  "_alloca", referenced from:
      _array_get_bang in libpd-osx.a(x_array.o)
      _list_split_anything in libpd-osx.a(x_list.o)
      _list_prepend_list in libpd-osx.a(x_list.o)
      _list_prepend_anything in libpd-osx.a(x_list.o)
      _list_append_list in libpd-osx.a(x_list.o)
      _list_append_anything in libpd-osx.a(x_list.o)
      _netreceive_readbin in libpd-osx.a(x_net.o)
      ...
```

Adding `-DHAVE_ALLOCA_H` to the other C flags fixed the build. This is on OS X 10.10, Xcode 6.1.
