### PR TITLE
Added UTIL_FILES and EXTRA_FILES to javalib target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -145,7 +145,7 @@ $(JNIH_FILE): $(JAVA_BASE)
 	javac -classpath java $^
 	javah -o $@ -classpath java org.puredata.core.PdBase
 
-$(PDJAVA_NATIVE): ${PD_FILES:.c=.o} ${JNI_FILE:.c=.o}
+$(PDJAVA_NATIVE): ${PD_FILES:.c=.o} ${UTIL_FILES:.c=.o} ${EXTRA_FILES:.c=.o} ${JNI_FILE:.c=.o}
 	mkdir -p $(PDJAVA_DIR)
 	$(CC) -o $(PDJAVA_NATIVE) $^ -lm -lpthread $(JAVA_LDFLAGS) 
 	cp $(PDJAVA_NATIVE) libs/


### PR DESCRIPTION
This fixes the error I was receiving when running `make javalib UTIL=true EXTRA=true`
```
Undefined symbols for architecture x86_64:
"_bonk_tilde_setup", referenced from:
_libpd_init in z_libpd.o
"_choice_setup", referenced from:
_libpd_init in z_libpd.o
"_expr_setup", referenced from:
_libpd_init in z_libpd.o
"_fiddle_tilde_setup", referenced from:
_libpd_init in z_libpd.o
"_loop_tilde_setup", referenced from:
_libpd_init in z_libpd.o
"_lrshift_tilde_setup", referenced from:
_libpd_init in z_libpd.o
"_pique_setup", referenced from:
_libpd_init in z_libpd.o
"_sigmund_tilde_setup", referenced from:
_libpd_init in z_libpd.o
"_stdout_setup", referenced from:
_libpd_init in z_libpd.o
ld: symbol(s) not found for architecture x86_64
clang: error: linker command failed with exit code 1 (use -v to see invocation)
make: *** [java-build/org/puredata/core/natives/mac///libpdnative.jnilib] Error 1
```

Running OS X 10.10.2.

Full disclosure: This is the first time I've worked with makefiles. I kind of just bumbled through this, but it's a small change, and should be easy enough to evaluate its sanity. Also my first PR. Hope it works!