### PR TITLE
Fix circular buffer read/write issue for compound PD messages.

### DIFF
--- a/libpd_wrapper/util/ringbuffer.h
+++ b/libpd_wrapper/util/ringbuffer.h
@@ -14,7 +14,9 @@ typedef struct ring_buffer {
     int size;
     char *buf_ptr;
     int write_idx;
+    int write_readable_idx;
     int read_idx;
+    int is_in_write_group;
 } ring_buffer;
 
 // Creates a ring buffer (returns NULL on failure).
@@ -40,5 +42,10 @@ int rb_write_to_buffer(ring_buffer *buffer, const char *src, int len);
 // buffer has enough data. Only to be called from a single reader thread.
 // Returns 0 on success.
 int rb_read_from_buffer(ring_buffer *buffer, char *dest, int len);
+
+// Wrap these functions around a series of rb_write_to_buffer operations,
+// to prevent reading between the writes.
+int rb_begin_write_group(ring_buffer *buffer);
+int rb_end_write_group(ring_buffer *buffer);
 
 #endif

--- a/libpd_wrapper/util/z_queued.c
+++ b/libpd_wrapper/util/z_queued.c
@@ -105,9 +105,11 @@ static void internal_printhook(const char *s) {
   int total = len + rest;
   if (rb_available_to_write(pd_receive_buffer) >= S_PD_PARAMS + total) {
     pd_params p = {LIBPD_PRINT, NULL, 0.0f, NULL, total};
+    rb_begin_write_group(pd_receive_buffer);
     rb_write_to_buffer(pd_receive_buffer, (const char *)&p, S_PD_PARAMS);
     rb_write_to_buffer(pd_receive_buffer, s, len);
     rb_write_to_buffer(pd_receive_buffer, padding, rest);
+    rb_end_write_group(pd_receive_buffer);
   }
 }
 
@@ -136,8 +138,10 @@ static void internal_listhook(const char *src, int argc, t_atom *argv) {
   int n = argc * S_ATOM;
   if (rb_available_to_write(pd_receive_buffer) >= S_PD_PARAMS + n) {
     pd_params p = {LIBPD_LIST, src, 0.0f, NULL, argc};
+    rb_begin_write_group(pd_receive_buffer);
     rb_write_to_buffer(pd_receive_buffer, (const char *)&p, S_PD_PARAMS);
     rb_write_to_buffer(pd_receive_buffer, (const char *)argv, n);
+    rb_end_write_group(pd_receive_buffer);
   }
 }
 
@@ -146,8 +150,10 @@ static void internal_messagehook(const char *src, const char* sym,
   int n = argc * S_ATOM;
   if (rb_available_to_write(pd_receive_buffer) >= S_PD_PARAMS + n) {
     pd_params p = {LIBPD_MESSAGE, src, 0.0f, sym, argc};
+    rb_begin_write_group(pd_receive_buffer);
     rb_write_to_buffer(pd_receive_buffer, (const char *)&p, S_PD_PARAMS);
     rb_write_to_buffer(pd_receive_buffer, (const char *)argv, n);
+    rb_end_write_group(pd_receive_buffer);
   }
 }
 


### PR DESCRIPTION
A fix for 
https://github.com/libpd/pd-for-android/issues/4
in which bad pd messages are sent out, by reading the buffer in between the multiple buffer writes of a compound pd messages (e.g. list, message).

and likely related to
https://github.com/libpd/libpd/issues/77
https://github.com/libpd/libpd/issues/43