### PR TITLE
start (and stop) Pd GUI from libpd

### DIFF
--- a/libpd_wrapper/s_libpdmidi.c
+++ b/libpd_wrapper/s_libpdmidi.c
@@ -52,7 +52,10 @@ void outmidi_byte(int port, int value) {
 }
 
 // The rest is not relevant to libpd.
-void sys_get_midi_apis(char *buf) {}
+void sys_get_midi_apis(char *buf)
+{
+    strcpy(buf, "{}");
+}
 void sys_listmididevs(void) {}
 void sys_get_midi_params(int *pnmidiindev, int *pmidiindev,
     int *pnmidioutdev, int *pmidioutdev) {}

--- a/libpd_wrapper/util/z_queued.c
+++ b/libpd_wrapper/util/z_queued.c
@@ -101,8 +101,9 @@ static void internal_printhook(const char *s) {
   static char padding[LIBPD_WORD_ALIGN];
   int len = (int) strlen(s) + 1; // remember terminating null char
   int rest = len % LIBPD_WORD_ALIGN;
+  int total;
   if (rest) rest = LIBPD_WORD_ALIGN - rest;
-  int total = len + rest;
+  total = len + rest;
   if (rb_available_to_write(pd_receive_buffer) >= S_PD_PARAMS + total) {
     pd_params p = {LIBPD_PRINT, NULL, 0.0f, NULL, total};
     rb_write_to_buffer(pd_receive_buffer, 3,
@@ -324,12 +325,13 @@ void libpd_queued_release() {
 }
 
 void libpd_queued_receive_pd_messages() {
+  char *end, *buffer;
+  static char temp_buffer[BUFFER_SIZE];
   size_t available = rb_available_to_read(pd_receive_buffer);
   if (!available) return;
-  static char temp_buffer[BUFFER_SIZE];
   rb_read_from_buffer(pd_receive_buffer, temp_buffer, (int) available);
-  char *end = temp_buffer + available;
-  char *buffer = temp_buffer;
+  *end = temp_buffer + available;
+  *buffer = temp_buffer;
   while (buffer < end) {
     pd_params *p = (pd_params *)buffer;
     buffer += S_PD_PARAMS;

--- a/libpd_wrapper/z_libpd.c
+++ b/libpd_wrapper/z_libpd.c
@@ -473,13 +473,14 @@ static void glist_maybevis(t_glist *gl)
     }
 }
 
-void libpd_start_gui(const char *libdir)
+int libpd_start_gui(const char *libdir)
 {
     t_canvas *x;
     for (x = pd_getcanvaslist(); x; x = x->gl_next)
         canvas_vis(x, 0);
     sys_nogui = 0;
-    sys_startgui(libdir);
+    if (sys_startgui(libdir))
+        return -1;
     for (x = pd_getcanvaslist(); x; x = x->gl_next)
         if (strcmp(x->gl_name->s_name, "_float_template") &&
             strcmp(x->gl_name->s_name, "_float_array_template") &&
@@ -488,6 +489,7 @@ void libpd_start_gui(const char *libdir)
                     glist_maybevis(x);
                     canvas_vis(x, 1);
     }
+    return 0;
 }
 
 void sys_stopgui( void);

--- a/libpd_wrapper/z_libpd.c
+++ b/libpd_wrapper/z_libpd.c
@@ -467,6 +467,7 @@ void libpd_start_gui(const char *libdir)
     sys_startgui(libdir);
     for (x = pd_getcanvaslist(); x; x = x->gl_next)
         if (strcmp(x->gl_name->s_name, "_float_template") &&
-            strcmp(x->gl_name->s_name, "_float_array_template"))
-                canvas_vis(x, 1);
+            strcmp(x->gl_name->s_name, "_float_array_template") &&
+                strcmp(x->gl_name->s_name, "_text_template"))
+                    canvas_vis(x, 1);
 }

--- a/libpd_wrapper/z_libpd.c
+++ b/libpd_wrapper/z_libpd.c
@@ -471,3 +471,14 @@ void libpd_start_gui(const char *libdir)
                 strcmp(x->gl_name->s_name, "_text_template"))
                     canvas_vis(x, 1);
 }
+
+void sys_stopgui( void);
+
+void libpd_stop_gui( void)
+{
+    t_canvas *x;
+    for (x = pd_getcanvaslist(); x; x = x->gl_next)
+        canvas_vis(x, 0);
+    sys_vgui("%s", "exit\n");
+    sys_stopgui();
+}

--- a/libpd_wrapper/z_libpd.c
+++ b/libpd_wrapper/z_libpd.c
@@ -19,6 +19,7 @@
 #include "s_stuff.h"
 #include "m_imp.h"
 #include "g_all_guis.h"
+#include "g_canvas.h"
 
 #if PD_MINOR_VERSION < 46
 # define HAVE_SCHED_TICK_ARG
@@ -453,4 +454,17 @@ void libpd_set_polyaftertouchhook(const t_libpd_polyaftertouchhook hook) {
 
 void libpd_set_midibytehook(const t_libpd_midibytehook hook) {
   libpd_midibytehook = hook;
+}
+
+void libpd_start_gui(const char *libdir)
+{
+    t_canvas *x;
+    for (x = pd_getcanvaslist(); x; x = x->gl_next)
+        canvas_vis(x, 0);
+    sys_nogui = 0;
+    sys_startgui(libdir);
+    for (x = pd_getcanvaslist(); x; x = x->gl_next)
+        if (strcmp(x->gl_name->s_name, "_float_template") &&
+            strcmp(x->gl_name->s_name, "_float_array_template"))
+                canvas_vis(x, 1);
 }

--- a/libpd_wrapper/z_libpd.c
+++ b/libpd_wrapper/z_libpd.c
@@ -458,6 +458,21 @@ void libpd_set_midibytehook(const t_libpd_midibytehook hook) {
   libpd_midibytehook = hook;
 }
 
+    /* recursively deselect everything in a gobj "g", if it happens to be
+    a glist, in preparation for deselecting g itself in glist_dselect() */
+static void glist_maybevis(t_glist *gl)
+{
+    t_gobj *g;
+    for (g = gl->gl_list; g; g = g->g_next)
+        if (pd_class(&g->g_pd) == canvas_class)
+            glist_maybevis((t_glist *)g);
+    if (gl->gl_havewindow)
+    {
+        canvas_vis(gl, 0);
+        canvas_vis(gl, 1);
+    }
+}
+
 void libpd_start_gui(const char *libdir)
 {
     t_canvas *x;
@@ -469,7 +484,10 @@ void libpd_start_gui(const char *libdir)
         if (strcmp(x->gl_name->s_name, "_float_template") &&
             strcmp(x->gl_name->s_name, "_float_array_template") &&
                 strcmp(x->gl_name->s_name, "_text_template"))
+    {
+                    glist_maybevis(x);
                     canvas_vis(x, 1);
+    }
 }
 
 void sys_stopgui( void);

--- a/libpd_wrapper/z_libpd.c
+++ b/libpd_wrapper/z_libpd.c
@@ -119,8 +119,9 @@ void libpd_closefile(void *x) {
 }
 
 int libpd_getdollarzero(void *x) {
+  int dzero;
   pd_pushsym((t_pd *)x);
-  int dzero = canvas_getdollarzero();
+  dzero = canvas_getdollarzero();
   pd_popsym((t_pd *)x);
   return dzero;
 }
@@ -178,8 +179,9 @@ static const t_sample sample_to_short = SHRT_MAX,
   } \
   return 0;
 
-int libpd_process_short(int ticks, const short *inBuffer, short *outBuffer) {
-  PROCESS(* short_to_sample, * sample_to_short)
+int libpd_process_short(const int ticks, const short *inBuffer,
+  short *outBuffer) {
+    PROCESS(* short_to_sample, * sample_to_short)
 }
 
 int libpd_process_float(int ticks, const float *inBuffer, float *outBuffer) {
@@ -202,9 +204,9 @@ int libpd_arraysize(const char *name) {
 #define MEMCPY(_x, _y) \
   GETARRAY \
   if (n < 0 || offset < 0 || offset + n > garray_npoints(garray)) return -2; \
-  t_word *vec = ((t_word *) garray_vec(garray)) + offset; \
+  { t_word *vec = ((t_word *) garray_vec(garray)) + offset; \
   int i; \
-  for (i = 0; i < n; i++) _x = _y;
+  for (i = 0; i < n; i++) _x = _y; }
 
 int libpd_read_array(float *dest, const char *name, int offset, int n) {
   MEMCPY(*dest++, (vec++)->w_float)

--- a/libpd_wrapper/z_libpd.h
+++ b/libpd_wrapper/z_libpd.h
@@ -108,6 +108,8 @@ EXTERN void libpd_set_aftertouchhook(const t_libpd_aftertouchhook hook);
 EXTERN void libpd_set_polyaftertouchhook(const t_libpd_polyaftertouchhook hook);
 EXTERN void libpd_set_midibytehook(const t_libpd_midibytehook hook);
 
+EXTERN void libpd_start_gui(const char *libdir);
+
 #ifdef __cplusplus
 }
 #endif

--- a/libpd_wrapper/z_libpd.h
+++ b/libpd_wrapper/z_libpd.h
@@ -109,6 +109,7 @@ EXTERN void libpd_set_polyaftertouchhook(const t_libpd_polyaftertouchhook hook);
 EXTERN void libpd_set_midibytehook(const t_libpd_midibytehook hook);
 
 EXTERN void libpd_start_gui(const char *libdir);
+EXTERN void libpd_stop_gui( void);
 
 #ifdef __cplusplus
 }

--- a/libpd_wrapper/z_libpd.h
+++ b/libpd_wrapper/z_libpd.h
@@ -108,7 +108,7 @@ EXTERN void libpd_set_aftertouchhook(const t_libpd_aftertouchhook hook);
 EXTERN void libpd_set_polyaftertouchhook(const t_libpd_polyaftertouchhook hook);
 EXTERN void libpd_set_midibytehook(const t_libpd_midibytehook hook);
 
-EXTERN void libpd_start_gui(const char *libdir);
+EXTERN int libpd_start_gui(const char *libdir);
 EXTERN void libpd_stop_gui( void);
 
 #ifdef __cplusplus

--- a/samples/c/guitest/Makefile
+++ b/samples/c/guitest/Makefile
@@ -1,0 +1,23 @@
+SRC_FILES = guitest.c
+LIBPD = ../../../libs/libpd.so
+TARGET = guitest
+
+CFLAGS = -I../../../pure-data/src -I../../../libpd_wrapper -O3
+
+.PHONY: clean clobber
+
+all:
+	cd ../../.. && make
+	make $(TARGET)
+
+$(TARGET): ${SRC_FILES:.c=.o} $(LIBPD)
+	gcc -o $(TARGET) $^ $(LIBPD)
+
+$(LIBPD):
+	cd ../../.. && make
+
+clean:
+	rm -f *.o
+
+clobber: clean
+	rm -f $(TARGET)

--- a/samples/c/guitest/guitest.c
+++ b/samples/c/guitest/guitest.c
@@ -59,7 +59,8 @@ int main(int argc, char **argv) {
         runawhile(1);
 
         printf("starting gui..\n");
-        libpd_start_gui("../../../pure-data/");
+        if (libpd_start_gui("../../../pure-data/"))
+            printf("gui startup failed\n");
 
         printf("running for 2000 more ticks...\n");
         runawhile(2);

--- a/samples/c/guitest/guitest.c
+++ b/samples/c/guitest/guitest.c
@@ -1,0 +1,70 @@
+#include <stdio.h>
+#include "z_libpd.h"
+
+void pdprint(const char *s)
+{
+    printf("%s", s);
+}
+
+void pdnoteon(int ch, int pitch, int vel)
+{
+    printf("noteon: %d %d %d\n", ch, pitch, vel);
+}
+
+float inbuf[64], outbuf[128];  // one input channel, two output channels
+                               // block size 64, one tick per buffer
+
+static void runawhile(int num_ticks)
+{
+    int ticksleft = num_ticks*1000;
+    while (ticksleft > 0)
+    {
+        // fill inbuf here
+        libpd_process_float(1, inbuf, outbuf);
+        // use outbuf here
+        sys_pollgui();
+        usleep(1451);   /* 1 tick is about 1.45 msec */
+        ticksleft -= 1;
+    }
+}
+
+extern int sys_verbose;
+
+int main(int argc, char **argv) {
+    if (argc < 3) {
+    fprintf(stderr, "usage: %s file folder\n", argv[0]);
+    return -1;
+    }
+
+    // init pd
+    int srate = 44100;
+    libpd_set_printhook((t_libpd_printhook)pdprint);
+    libpd_set_noteonhook((t_libpd_noteonhook)pdnoteon);
+    libpd_init();
+    libpd_init_audio(1, 2, srate);
+
+    // compute audio    [; pd dsp 1(
+    libpd_start_message(1); // one entry in list
+    libpd_add_float(1.0f);
+    libpd_finish_message("pd", "dsp");
+
+    // open patch       [; pd open file folder(
+    void *file = libpd_openfile(argv[1], argv[2]);
+
+    // now run pd
+
+    printf("running nogui for 1000 ticks...\n");
+
+    runawhile(1);
+
+    printf("starting gui..\n");
+    libpd_start_gui("../../../pure-data/");
+
+    printf("running for 5000 more ticks...\n");
+    runawhile(5);
+
+    printf("Closing and exiting\n");
+    libpd_closefile(file);
+
+    return 0;
+}

--- a/samples/c/guitest/guitest.c
+++ b/samples/c/guitest/guitest.c
@@ -37,7 +37,7 @@ int main(int argc, char **argv) {
     }
 
     // init pd
-    int srate = 44100;
+    int srate = 44100, foo;
     libpd_set_printhook((t_libpd_printhook)pdprint);
     libpd_set_noteonhook((t_libpd_noteonhook)pdnoteon);
     libpd_init();
@@ -52,16 +52,20 @@ int main(int argc, char **argv) {
     void *file = libpd_openfile(argv[1], argv[2]);
 
     // now run pd
+    for (foo = 0; foo < 2; foo++)  /* note: doesn't yet work the second time */
+    {
+        printf("running nogui for 1000 ticks...\n");
 
-    printf("running nogui for 1000 ticks...\n");
+        runawhile(1);
 
-    runawhile(1);
+        printf("starting gui..\n");
+        libpd_start_gui("../../../pure-data/");
 
-    printf("starting gui..\n");
-    libpd_start_gui("../../../pure-data/");
+        printf("running for 2000 more ticks...\n");
+        runawhile(2);
 
-    printf("running for 5000 more ticks...\n");
-    runawhile(5);
+        libpd_stop_gui();
+    }
 
     printf("Closing and exiting\n");
     libpd_closefile(file);

--- a/samples/c/guitest/test.pd
+++ b/samples/c/guitest/test.pd
@@ -1,0 +1,17 @@
+#N canvas 411 292 450 300 10;
+#X obj 97 64 loadbang;
+#X obj 97 131 print;
+#X obj 188 73 osc~ 400;
+#X obj 179 104 dac~;
+#X obj 97 107 f 0;
+#X obj 128 107 + 1;
+#X obj 46 132 noteout;
+#X obj 97 86 metro 1000;
+#X connect 0 0 7 0;
+#X connect 2 0 3 0;
+#X connect 2 0 3 1;
+#X connect 4 0 1 0;
+#X connect 4 0 5 0;
+#X connect 4 0 6 0;
+#X connect 5 0 4 1;
+#X connect 7 0 4 0;


### PR DESCRIPTION
introduces functions libpd_start_gui() and libpd_stop_gui().  Requires corresponding updates to Pd
source.

Also compile 'fixes' for MSVC which hates declarations that aren't at heads of blocks; and
fixes a problem if someone calls midi_get_APIs() (which gets done when GUI is started).
