### PR TITLE
Fixed some cpplib build issues under Windows/Mingw.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -24,7 +24,7 @@ else
       -I"$(JAVA_HOME)/include" -I"$(JAVA_HOME)/include/win32"
     MINGW_LDFLAGS = -shared -lws2_32 -lkernel32
     LDFLAGS = $(MINGW_LDFLAGS) -Wl,--output-def=libs/libpd.def \
-      -Wl,--out-implib=libs/libpd.lib
+      -Wl,--out-implib=libs/libpd.lib -Wl,--export-all-symbols
     CSHARP_LDFLAGS = $(MINGW_LDFLAGS) -Wl,--output-def=libs/libpdcsharp.def \
       -Wl,--out-implib=libs/libpdcsharp.lib
     CPP_LDFLAGS = $(LDFLAGS)

--- a/cpp/PdBase.cpp
+++ b/cpp/PdBase.cpp
@@ -19,7 +19,10 @@
 #include <iostream>
 
 #ifdef LIBPD_USE_STD_MUTEX
-    #if __cplusplus <= 201103L // C++ 11 check
+	#ifdef _WIN32
+		#define _LOCK() mutex.lock()
+		#define _UNLOCK() mutex.unlock()
+    #elif __cplusplus <= 201103L // C++ 11 check
         #define _LOCK() mutex.lock()
         #define _UNLOCK() mutex.unlock()
     #endif

--- a/cpp/PdBase.hpp
+++ b/cpp/PdBase.hpp
@@ -24,7 +24,10 @@
 
 // define this to use C++11 std::mutex for locking
 #ifdef LIBPD_USE_STD_MUTEX
-    #if __cplusplus < 201103L
+	#ifdef _WIN32
+		// __cplusplus is badly behaved in windows. just assume we have mutex
+		#include <mutex>
+	#elif __cplusplus < 201103L		
         #warning std::mutex requires C++11
     #else
         #include <mutex>

--- a/samples/c/pdtest/Makefile
+++ b/samples/c/pdtest/Makefile
@@ -9,6 +9,7 @@ else
   ifeq ($(OS), Windows_NT)  # Windows, use Mingw
     SOLIB_EXT = dll
     PDNATIVE_PLATFORM = windows
+    CC = gcc
   else  # Assume Linux
     SOLIB_EXT = so
     PDNATIVE_PLATFORM = linux

--- a/samples/cpp/pdtest_rtaudio/Makefile
+++ b/samples/cpp/pdtest_rtaudio/Makefile
@@ -23,6 +23,7 @@ else
     SOLIB_PREFIX = 
     PDNATIVE_PLATFORM = windows
     CXXFLAGS = -D__WINDOWS_DS__
+    AUDIO_API = -lole32 -loleaut32 -ldsound -lwinmm
   else  # Assume Linux
     SOLIB_EXT = so
     PDNATIVE_PLATFORM = linux
@@ -42,7 +43,7 @@ CXXFLAGS += -I$(LIBPD_DIR)/pure-data/src -I$(LIBPD_DIR)/libpd_wrapper -I$(LIBPD_
 .PHONY: clean clobber
 
 $(TARGET): ${SRC_FILES:.cpp=.o} $(LIBPD_CPP)
-	g++ -o $(TARGET) $^ $(LIBPD_CPP) $(AUDIO_API)
+	g++ -o $(TARGET) $^ $(AUDIO_API)
 	if [ $(PDNATIVE_PLATFORM) == "mac" ]; then mkdir -p ./libs && cp $(LIBPD_CPP) ./libs; fi
 
 $(LIBPD_CPP):


### PR DESCRIPTION
Symbols weren't exporting for the cpplib under Windows/Mingw, so I patched the Makefile.

Also patched the makefiles for two samples to get them running under Windows/Mingw. 

> gcc version 5.2.0 (Rev3, Built by MSYS2 project)
