### PR TITLE
Fix AVAudioSession method call on iOS 5 and below

### DIFF
--- a/objc/PdAudioController.m
+++ b/objc/PdAudioController.m
@@ -94,7 +94,13 @@
 									inputEnabled:(BOOL)inputEnabled
 								   mixingEnabled:(BOOL)mixingEnabled {
 	PdAudioStatus status = PdAudioOK;
-	if (inputEnabled && ![AVAudioSession sharedInstance].inputAvailable) {
+  BOOL isInputAvailable;
+#if __IPHONE_OS_VERSION_MIN_REQUIRED >= 60000
+  isInputAvailable = [AVAudioSession sharedInstance].inputAvailable;
+#else
+  isInputAvailable = [AVAudioSession sharedInstance].inputIsAvailable;
+#endif
+	if (inputEnabled && !isInputAvailable) {
 		inputEnabled = NO;
 		status |= PdAudioPropertyChanged;
 	}


### PR DESCRIPTION
[AVAudioSession sharedInstance].inputAvailable is on iOS 6 and above, causes crashes on iOS 5. Adding preproccessor directives to use both the old/deprecated and newer method names.