### PR TITLE
Use the github puredata submodule and only include obj files as public headers

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -3,4 +3,4 @@
 	url = git://github.com/nettoyeurny/opensl_stream.git
 [submodule "pure-data"]
 	path = pure-data
-	url = git://git.code.sf.net/p/pure-data/pure-data
+	url = git://github.com/pure-data/pure-data.git

--- a/libpd.podspec
+++ b/libpd.podspec
@@ -13,6 +13,7 @@ Pod::Spec.new do |spec|
                       'pure-data/extra/**/*.{h,c}',
                       'libpd_wrapper/**/*.{h,c}',
                       'objc/**/*.{h,m}'
+  spec.public_header_files = 'objc/**/*.{h,m}'
   spec.ios.deployment_target = '6.0'
   spec.requires_arc = false
   spec.frameworks = 'Foundation', 'AudioToolbox', 'AVFoundation'

--- a/libpd.podspec
+++ b/libpd.podspec
@@ -13,7 +13,7 @@ Pod::Spec.new do |spec|
                       'pure-data/extra/**/*.{h,c}',
                       'libpd_wrapper/**/*.{h,c}',
                       'objc/**/*.{h,m}'
-  spec.public_header_files = 'objc/**/*.{h,m}'
+  spec.public_header_files = 'objc/**/*.{h}'
   spec.ios.deployment_target = '6.0'
   spec.requires_arc = false
   spec.frameworks = 'Foundation', 'AudioToolbox', 'AVFoundation'


### PR DESCRIPTION
I can break this into two pull requests if needed, but one fixes the issue where git://git.code.sf.net/p/pure-data/pure-data is offline and therefore you can't pull the submodule.

The other fixes issues with building cocoapod frameworks and using swift since it includes header files that won't compile correctly in the libpd-umbrella.h file. This exposes only the obj folder to the umbrella file fixing build issues.