### PR TITLE
fix semantic warning

### DIFF
--- a/libpd_wrapper/z_libpd.c
+++ b/libpd_wrapper/z_libpd.c
@@ -610,7 +610,7 @@ t_pdinstance *libpd_get_instance(int index) {
 #endif
 }
 
-int libpd_num_instances() {
+int libpd_num_instances(void) {
 #ifdef PDINSTANCE
   return pd_ninstances;
 #else

--- a/libpd_wrapper/z_libpd.h
+++ b/libpd_wrapper/z_libpd.h
@@ -137,7 +137,7 @@ EXTERN t_pdinstance *libpd_get_instance(int index);
 
 /// get the number of pd instances
 /// returns 1 when libpd is not compiled with PDINSTANCE
-EXTERN int libpd_num_instances();
+EXTERN int libpd_num_instances(void);
 
 #ifdef __cplusplus
 }


### PR DESCRIPTION
A simple correction to avoid a warning.