### PR TITLE
Support for Appveyor CI

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,0 +1,25 @@
+
+environment:
+   matrix:
+      - CONFIGURATION: Release
+        PLATFORM: x64
+        MINGW: mingw64
+      - CONFIGURATION: Release
+        PLATFORM: x64
+        MINGW: mingw32
+
+os: Visual Studio 2015
+
+install:
+    - git submodule update --init --recursive
+    - C:\msys64\usr\bin\bash -lc "pacman -Syuu --noconfirm"
+    - C:\msys64\usr\bin\bash -lc "pacman -S --noconfirm --needed make mingw-w64-i686-gcc mingw-w64-x86_64-gcc"
+    - C:\msys64\usr\bin\bash -lc "pacman -S --noconfirm --needed mingw-w64-cross-winpthreads-git"
+build_script:
+    - 'if "%MINGW%"=="mingw64" C:\msys64\usr\bin\bash -lc "cd $APPVEYOR_BUILD_FOLDER/appveyor; ./mingw64_build_libpd.bat"'
+    - 'if "%MINGW%"=="mingw32" C:\msys64\usr\bin\bash -lc "cd $APPVEYOR_BUILD_FOLDER/appveyor; ./mingw32_build_libpd.bat"'
+
+notifications:
+
+  - provider: Email
+    on_build_status_changed: false

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,11 +1,9 @@
 
 environment:
    matrix:
-      - CONFIGURATION: Release
-        PLATFORM: x64
+      - PLATFORM: x64
         MINGW: mingw64
-      - CONFIGURATION: Release
-        PLATFORM: x64
+      - PLATFORM: x64
         MINGW: mingw32
 
 os: Visual Studio 2015

--- a/appveyor/mingw32_build_libpd.bat
+++ b/appveyor/mingw32_build_libpd.bat
@@ -1,0 +1,5 @@
+SET MSYS=C:\msys64
+SET MINGW=%MSYS%\mingw32
+SET PATH=%MINGW%\bin;%MSYS%\usr\bin
+make -C ../ clobber
+make -C ../ libpd MULTI=true

--- a/appveyor/mingw64_build_libpd.bat
+++ b/appveyor/mingw64_build_libpd.bat
@@ -1,0 +1,6 @@
+SET MSYS=C:\msys64
+SET MINGW=%MSYS%\mingw64
+SET PATH=%MINGW%\bin;%MSYS%\usr\bin
+make -C ../ clobber
+:: force long long 64 bit int type as mingw64 uses 32 bit by default
+make -C ../ libpd MULTI=true ADDITIONAL_CFLAGS='-DPD_LONGINTTYPE="long long"'


### PR DESCRIPTION
Add the appveyor support (for Windows) with *mingw32* & *mingw64*. 
It compiles *libpd* (the C core). Not the *csharp* lib but we can add other options for this. There is no test but it would good to add them in the future. The **MULTI** option is activated by default. 

I didn't manage to setup everything without calling *.bat* files. I would have preferred to have something in one line per option like:
```
- C:\msys64\usr\bin\bash -lc "cd $APPVEYOR_BUILD_FOLDER; SET PATH=C:\msys64\usr\bin; make libpd (It's a simplified example, it doesn't work) 
```
But I couldn't manage to setup the right paths without the *.bat* files.

PS: It would be cool now if Travis and Appveyor could be activated for the repository (and perhaps to add links in the README).  

  