### PR TITLE
buffered iOS audio unit

### DIFF
--- a/libpd.podspec
+++ b/libpd.podspec
@@ -14,8 +14,8 @@ Pod::Spec.new do |spec|
                       'libpd_wrapper/**/*.{h,c}',
                       'objc/**/*.{h,m}'
   spec.public_header_files = 'objc/**/*.{h}'
-  spec.ios.deployment_target = '6.0'
-  spec.requires_arc = false
+  spec.ios.deployment_target = '8.0'
+  spec.requires_arc = true
   spec.frameworks = 'Foundation', 'AudioToolbox', 'AVFoundation'
   spec.compiler_flags = '-DPD', '-DUSEAPI_DUMMY', '-DHAVE_UNISTD_H', '-DLIBPD_EXTRA', '-fcommon'
   spec.exclude_files = 'pure-data/src/s_audio_alsa.h',
@@ -40,5 +40,8 @@ Pod::Spec.new do |spec|
                        'pure-data/src/s_entry.c',
                        'pure-data/src/s_watchdog.c',
                        'pure-data/src/u_pdreceive.c',
-                       'pure-data/src/u_pdsend.c'
+                       'pure-data/src/u_pdsend.c',
+                       'objc/TPCircularBuffer/TPCircularBuffer.h',
+                       'objc/TPCircularBuffer/TPCircularBuffer.m'
+  spec.dependency 'TPCircularBuffer'
 end

--- a/libpd.xcodeproj/project.pbxproj
+++ b/libpd.xcodeproj/project.pbxproj
@@ -174,6 +174,10 @@
 		306DBE6116BC6710007CF226 /* z_queued.c in Sources */ = {isa = PBXBuildFile; fileRef = 306DBE5416BC6710007CF226 /* z_queued.c */; };
 		306DBE6216BC6710007CF226 /* z_queued.h in Headers */ = {isa = PBXBuildFile; fileRef = 306DBE5516BC6710007CF226 /* z_queued.h */; };
 		306DBE6316BC6710007CF226 /* z_queued.h in Headers */ = {isa = PBXBuildFile; fileRef = 306DBE5516BC6710007CF226 /* z_queued.h */; };
+		30875D9120266D6000FA2C85 /* TPCircularBuffer.h in Headers */ = {isa = PBXBuildFile; fileRef = 30875D8F20266D6000FA2C85 /* TPCircularBuffer.h */; };
+		30875D9220266D6000FA2C85 /* TPCircularBuffer.h in Headers */ = {isa = PBXBuildFile; fileRef = 30875D8F20266D6000FA2C85 /* TPCircularBuffer.h */; };
+		30875D9320266D6000FA2C85 /* TPCircularBuffer.c in Sources */ = {isa = PBXBuildFile; fileRef = 30875D9020266D6000FA2C85 /* TPCircularBuffer.c */; };
+		30875D9420266D6000FA2C85 /* TPCircularBuffer.c in Sources */ = {isa = PBXBuildFile; fileRef = 30875D9020266D6000FA2C85 /* TPCircularBuffer.c */; };
 		3088883216BCB4A400781682 /* z_print_util.c in Sources */ = {isa = PBXBuildFile; fileRef = 3088882C16BCB4A400781682 /* z_print_util.c */; };
 		3088883316BCB4A400781682 /* z_print_util.c in Sources */ = {isa = PBXBuildFile; fileRef = 3088882C16BCB4A400781682 /* z_print_util.c */; };
 		3088883416BCB4A400781682 /* z_print_util.h in Headers */ = {isa = PBXBuildFile; fileRef = 3088882D16BCB4A400781682 /* z_print_util.h */; };
@@ -520,6 +524,8 @@
 		306DBE5116BC6710007CF226 /* ringbuffer.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ringbuffer.h; sourceTree = "<group>"; };
 		306DBE5416BC6710007CF226 /* z_queued.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = z_queued.c; sourceTree = "<group>"; };
 		306DBE5516BC6710007CF226 /* z_queued.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = z_queued.h; sourceTree = "<group>"; };
+		30875D8F20266D6000FA2C85 /* TPCircularBuffer.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = TPCircularBuffer.h; sourceTree = "<group>"; };
+		30875D9020266D6000FA2C85 /* TPCircularBuffer.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = TPCircularBuffer.c; sourceTree = "<group>"; };
 		3088882C16BCB4A400781682 /* z_print_util.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = z_print_util.c; sourceTree = "<group>"; };
 		3088882D16BCB4A400781682 /* z_print_util.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = z_print_util.h; sourceTree = "<group>"; };
 		30ABBFC61CA8A67000E3722F /* x_vexp_fun.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = x_vexp_fun.c; sourceTree = "<group>"; };
@@ -659,6 +665,7 @@
 				110E6DD1147B838F00282ABC /* PdAudioController.m */,
 				110E6DCE147B838E00282ABC /* AudioHelpers.h */,
 				110E6DCF147B838E00282ABC /* AudioHelpers.m */,
+				30875D8E20266D6000FA2C85 /* TPCircularBuffer */,
 			);
 			name = audio;
 			sourceTree = "<group>";
@@ -687,6 +694,15 @@
 				306DBE5516BC6710007CF226 /* z_queued.h */,
 			);
 			path = util;
+			sourceTree = "<group>";
+		};
+		30875D8E20266D6000FA2C85 /* TPCircularBuffer */ = {
+			isa = PBXGroup;
+			children = (
+				30875D8F20266D6000FA2C85 /* TPCircularBuffer.h */,
+				30875D9020266D6000FA2C85 /* TPCircularBuffer.c */,
+			);
+			path = TPCircularBuffer;
 			sourceTree = "<group>";
 		};
 		30CEFE211A6A5E5F000E3BAE /* src */ = {
@@ -916,6 +932,7 @@
 				30C3D3011FAA200100C67F08 /* z_hooks.h in Headers */,
 				30C3D3021FAA200100C67F08 /* PdAudioController.h in Headers */,
 				30C3D3031FAA200100C67F08 /* PdAudioUnit.h in Headers */,
+				30875D9220266D6000FA2C85 /* TPCircularBuffer.h in Headers */,
 				30C3D3041FAA200100C67F08 /* PdMidiDispatcher.h in Headers */,
 				30C3D3051FAA200100C67F08 /* x_vexp.h in Headers */,
 				30C3D3061FAA200100C67F08 /* ringbuffer.h in Headers */,
@@ -935,6 +952,7 @@
 				304C8EDA1860FA2D006D2159 /* z_hooks.h in Headers */,
 				110E6DD6147B838F00282ABC /* PdAudioController.h in Headers */,
 				110E6DD8147B838F00282ABC /* PdAudioUnit.h in Headers */,
+				30875D9120266D6000FA2C85 /* TPCircularBuffer.h in Headers */,
 				30E9358616ADA07E009BFE25 /* PdMidiDispatcher.h in Headers */,
 				30ABBFD01CA8A67000E3722F /* x_vexp.h in Headers */,
 				306DBE5A16BC6710007CF226 /* ringbuffer.h in Headers */,
@@ -1254,6 +1272,7 @@
 				30C3D30F1FAA200100C67F08 /* d_fft.c in Sources */,
 				30C3D3101FAA200100C67F08 /* x_array.c in Sources */,
 				30C3D3111FAA200100C67F08 /* d_filter.c in Sources */,
+				30875D9420266D6000FA2C85 /* TPCircularBuffer.c in Sources */,
 				30C3D3121FAA200100C67F08 /* d_global.c in Sources */,
 				30C3D3131FAA200100C67F08 /* d_math.c in Sources */,
 				30C3D3141FAA200100C67F08 /* d_misc.c in Sources */,
@@ -1355,6 +1374,7 @@
 				0E82A04312EEFDEE0053280E /* d_fft.c in Sources */,
 				30377F451866680A0026ED3E /* x_array.c in Sources */,
 				0E82A04612EEFDEE0053280E /* d_filter.c in Sources */,
+				30875D9320266D6000FA2C85 /* TPCircularBuffer.c in Sources */,
 				0E82A04712EEFDEE0053280E /* d_global.c in Sources */,
 				0E82A04812EEFDEE0053280E /* d_math.c in Sources */,
 				0E82A04912EEFDEE0053280E /* d_misc.c in Sources */,

--- a/objc/PdAudioController.h
+++ b/objc/PdAudioController.h
@@ -15,7 +15,7 @@
 typedef enum PdAudioStatus {
 	PdAudioOK = 0,              // success
 	PdAudioError = -1,          // unrecoverable error
-	PdAudioPropertyChanged = 1  // some properties have changed to run correctly (not fatal)
+	PdAudioPropertyChanged = 1  // some properties have changed to run correctly
 } PdAudioStatus;
 
 /// PdAudioController: A class for managing PdAudioUnit within iOS
@@ -39,30 +39,47 @@ typedef enum PdAudioStatus {
 /// Check or set the active status of the audio unit
 @property (nonatomic, getter=isActive) BOOL active;
 
-/// Init with a custom pd audio unit. Derive PdAudioUnit when you need to access
-/// to the raw samples when using, for instance, AudioBus, and call this method after init.
+/// Init with a custom pd audio unit.
+///
+/// Derive PdAudioUnit when you need to access to the raw samples when using,
+/// for instance, AudioBus, and call this method after init.
 - (instancetype)initWithAudioUnit:(PdAudioUnit *)audioUnit;
 
-/// Configure the audio with the specified samplerate, as well as number of output channels (which will also be the number of
-/// input channels if input is enable).  Note that this method has three possible outcomes: success, failure, or conditional
-/// success, where parameters had to be adjusted to set up the audio.  In the third case, you can query the sample rate and
-/// channel properties to determine whether the selected configuration is acceptable.  Specifying mixingEnabled = YES will
-/// allow the app to continue playing audio along with other apps (such as Music).
+/// Configure the audio with the specified samplerate, as well as number of
+/// output channels (which will also be the number of input channels if input is
+/// enabled).
+///
+/// Note that this method has three possible outcomes: success, failure, or
+/// conditional success, where parameters had to be adjusted to set up the
+/// audio. In the third case, you can query the sample rate and channel
+/// properties to determine whether the selected configuration is acceptable.
+///
+/// Specifying mixingEnabled = YES will allow the app to continue playing audio
+/// along with other apps (such as Music).
+///
+/// Uses AU input and output buffering by default.
 - (PdAudioStatus)configurePlaybackWithSampleRate:(int)sampleRate
                                   numberChannels:(int)numChannels
                                     inputEnabled:(BOOL)inputEnabled
                                    mixingEnabled:(BOOL)mixingEnabled;
 
-/// Configure audio for ambient use, without input channels.  Specifying mixingEnabled = YES will allow the app to continue
-/// playing audio along with other apps (such as iPod music player).
+/// Configure audio for ambient use, without input channels.
+///
+/// Specifying mixingEnabled = YES will allow the app to continue playing audio
+/// along with other apps (such as iPod music player).
+///
+/// Uses AU input and output buffering by default.
 - (PdAudioStatus)configureAmbientWithSampleRate:(int)sampleRate
                                  numberChannels:(int)numChannels
                                   mixingEnabled:(BOOL)mixingEnabled;
 
-/// Configure the ticksPerBuffer parameter, which will change the audio sessions IO buffer size.
-/// This can be done on the fly, while audio is running.  Note that the audio session only accepts
-/// values that correspond to a number of frames that are a power of 2 and sometimes this value
-/// is ignored by the audio unit, which tries to work with whatever number of frames it is provided.
+/// Configure the ticksPerBuffer parameter, which will change the audio session
+/// IO buffer size. This can be done on the fly, while audio is running.
+///
+/// Note that the audio session only accepts values that correspond to a number
+/// of frames that are a power of 2 and sometimes this value is ignored by the
+/// audio unit, which tries to work with whatever number of frames it is
+/// provided.
 - (PdAudioStatus)configureTicksPerBuffer:(int)ticksPerBuffer;
 
 /// Print current settings to the console.

--- a/objc/PdAudioUnit.h
+++ b/objc/PdAudioUnit.h
@@ -20,11 +20,13 @@
 ///
 @interface PdAudioUnit : NSObject
 
-/// A reference to the audio unit, which can be used to query or set other properties
+/// A reference to the audio unit which can be used to query or set other
+/// properties.
 @property (nonatomic, readonly) AudioUnit audioUnit;
 
-/// A reference to the audio unit callback function. Override the getter method if you
-/// want to subclass PdAudioUnit and implement your own custom sample rendering:
+/// A reference to the audio unit callback function. Override the getter method
+/// if you want to subclass PdAudioUnit and implement your own custom sample
+/// rendering.
 ///
 /// In your custom PdAudioUnit subclass .m:
 ///
@@ -35,7 +37,7 @@
 ///                                  UInt32 inBusNumber,
 ///                                  UInt32 inNumberFrames,
 ///                                  AudioBufferList *ioData) {
-///     // do something with the samples, see AudioRenderCallback in PdAudioUnit.m
+///     // do something with the samples, see PdAudioUnit.m render callbacks
 ///     return noErr;
 /// }
 ///
@@ -46,20 +48,24 @@
 ///
 @property (nonatomic, readonly) AURenderCallback renderCallback;
 
-/// Check or set the active status of the audio unit
+/// Check or set the active status of the audio unit.
 @property (nonatomic, getter=isActive) BOOL active;
 
-/// The configure method sets all parameters of the audio unit that may require it to be
-/// recreated at the same time.  This is an expensive process and will stop the audio unit
-/// before any reconstruction, causing a momentary pause in audio and UI if
-/// run from the main thread.  Returns zero on success.
-- (int)configureWithSampleRate:(Float64)sampleRate numberChannels:(int)numChannels inputEnabled:(BOOL)inputEnabled;
+/// The configure method sets all parameters of the audio unit that may require
+/// it to be recreated at the same time. This is an expensive process and will
+/// stop the audio unit before any reconstruction, causing a momentary pause in
+/// audio and UI if run from the main thread.
+/// Returns zero on success.
+- (int)configureWithSampleRate:(Float64)sampleRate
+			    numberChannels:(int)numChannels
+                  inputEnabled:(BOOL)inputEnabled;
 
 /// Print info on the audio unit settings to the console
 - (void)print;
 
 /// Called by configureWithSampleRate when setting up the internal audio unit.
 /// Default format: 32 bit, floating point, linear PCM, interleaved
-- (AudioStreamBasicDescription)ASBDForSampleRate:(Float64)sampleRate numberChannels:(UInt32)numChannels;
+- (AudioStreamBasicDescription)ASBDForSampleRate:(Float64)sampleRate
+                                  numberChannels:(UInt32)numChannels;
 
 @end

--- a/objc/PdAudioUnit.m
+++ b/objc/PdAudioUnit.m
@@ -96,7 +96,7 @@ static const AudioUnitElement kOutputElement = 0;
     TPCircularBufferInit(&_renderedBuffer, kRenderedBufferLength);
     // When input is enabled, we insert silent samples which size is equal to PdBase's block size.
     // This affects latency, but since processing of audio samples in `PdBase` is done for each block size,
-    // it is necessary to process the number of frames passed in` AudioRenderCallback`.
+    // it is necessary to process the number of frames passed in `AudioRenderCallback()`.
     if (_inputEnabled) {
         uint32_t blockBytes = (uint32_t)self.samplesPerBlock * sizeof(Float32);
         uint32_t availableBytes;

--- a/objc/PdAudioUnit.m
+++ b/objc/PdAudioUnit.m
@@ -10,7 +10,6 @@
 
 #import "PdAudioUnit.h"
 #import "PdBase.h"
-#import "PdBuffer.h"
 #import "AudioHelpers.h"
 #import <AudioToolbox/AudioToolbox.h>
 #import "TPCircularBuffer.h"

--- a/objc/TPCircularBuffer/TPCircularBuffer.c
+++ b/objc/TPCircularBuffer/TPCircularBuffer.c
@@ -1,0 +1,149 @@
+//
+//  TPCircularBuffer.c
+//  Circular/Ring buffer implementation
+//
+//  https://github.com/michaeltyson/TPCircularBuffer
+//
+//  Created by Michael Tyson on 10/12/2011.
+//
+//  Copyright (C) 2012-2013 A Tasty Pixel
+//
+//  This software is provided 'as-is', without any express or implied
+//  warranty.  In no event will the authors be held liable for any damages
+//  arising from the use of this software.
+//
+//  Permission is granted to anyone to use this software for any purpose,
+//  including commercial applications, and to alter it and redistribute it
+//  freely, subject to the following restrictions:
+//
+//  1. The origin of this software must not be misrepresented; you must not
+//     claim that you wrote the original software. If you use this software
+//     in a product, an acknowledgment in the product documentation would be
+//     appreciated but is not required.
+//
+//  2. Altered source versions must be plainly marked as such, and must not be
+//     misrepresented as being the original software.
+//
+//  3. This notice may not be removed or altered from any source distribution.
+//
+
+#include "TPCircularBuffer.h"
+#include <mach/mach.h>
+#include <stdio.h>
+#include <stdlib.h>
+
+#define reportResult(result,operation) (_reportResult((result),(operation),strrchr(__FILE__, '/')+1,__LINE__))
+static inline bool _reportResult(kern_return_t result, const char *operation, const char* file, int line) {
+    if ( result != ERR_SUCCESS ) {
+        printf("%s:%d: %s: %s\n", file, line, operation, mach_error_string(result)); 
+        return false;
+    }
+    return true;
+}
+
+bool _TPCircularBufferInit(TPCircularBuffer *buffer, uint32_t length, size_t structSize) {
+    
+    assert(length > 0);
+    
+    if ( structSize != sizeof(TPCircularBuffer) ) {
+        fprintf(stderr, "TPCircularBuffer: Header version mismatch. Check for old versions of TPCircularBuffer in your project\n");
+        abort();
+    }
+    
+    // Keep trying until we get our buffer, needed to handle race conditions
+    int retries = 3;
+    while ( true ) {
+
+        buffer->length = (uint32_t)round_page(length);    // We need whole page sizes
+
+        // Temporarily allocate twice the length, so we have the contiguous address space to
+        // support a second instance of the buffer directly after
+        vm_address_t bufferAddress;
+        kern_return_t result = vm_allocate(mach_task_self(),
+                                           &bufferAddress,
+                                           buffer->length * 2,
+                                           VM_FLAGS_ANYWHERE); // allocate anywhere it'll fit
+        if ( result != ERR_SUCCESS ) {
+            if ( retries-- == 0 ) {
+                reportResult(result, "Buffer allocation");
+                return false;
+            }
+            // Try again if we fail
+            continue;
+        }
+        
+        // Now replace the second half of the allocation with a virtual copy of the first half. Deallocate the second half...
+        result = vm_deallocate(mach_task_self(),
+                               bufferAddress + buffer->length,
+                               buffer->length);
+        if ( result != ERR_SUCCESS ) {
+            if ( retries-- == 0 ) {
+                reportResult(result, "Buffer deallocation");
+                return false;
+            }
+            // If this fails somehow, deallocate the whole region and try again
+            vm_deallocate(mach_task_self(), bufferAddress, buffer->length);
+            continue;
+        }
+        
+        // Re-map the buffer to the address space immediately after the buffer
+        vm_address_t virtualAddress = bufferAddress + buffer->length;
+        vm_prot_t cur_prot, max_prot;
+        result = vm_remap(mach_task_self(),
+                          &virtualAddress,   // mirror target
+                          buffer->length,    // size of mirror
+                          0,                 // auto alignment
+                          0,                 // force remapping to virtualAddress
+                          mach_task_self(),  // same task
+                          bufferAddress,     // mirror source
+                          0,                 // MAP READ-WRITE, NOT COPY
+                          &cur_prot,         // unused protection struct
+                          &max_prot,         // unused protection struct
+                          VM_INHERIT_DEFAULT);
+        if ( result != ERR_SUCCESS ) {
+            if ( retries-- == 0 ) {
+                reportResult(result, "Remap buffer memory");
+                return false;
+            }
+            // If this remap failed, we hit a race condition, so deallocate and try again
+            vm_deallocate(mach_task_self(), bufferAddress, buffer->length);
+            continue;
+        }
+        
+        if ( virtualAddress != bufferAddress+buffer->length ) {
+            // If the memory is not contiguous, clean up both allocated buffers and try again
+            if ( retries-- == 0 ) {
+                printf("Couldn't map buffer memory to end of buffer\n");
+                return false;
+            }
+
+            vm_deallocate(mach_task_self(), virtualAddress, buffer->length);
+            vm_deallocate(mach_task_self(), bufferAddress, buffer->length);
+            continue;
+        }
+        
+        buffer->buffer = (void*)bufferAddress;
+        buffer->fillCount = 0;
+        buffer->head = buffer->tail = 0;
+        buffer->atomic = true;
+        
+        return true;
+    }
+    return false;
+}
+
+void TPCircularBufferCleanup(TPCircularBuffer *buffer) {
+    vm_deallocate(mach_task_self(), (vm_address_t)buffer->buffer, buffer->length * 2);
+    memset(buffer, 0, sizeof(TPCircularBuffer));
+}
+
+void TPCircularBufferClear(TPCircularBuffer *buffer) {
+    uint32_t fillCount;
+    if ( TPCircularBufferTail(buffer, &fillCount) ) {
+        TPCircularBufferConsume(buffer, fillCount);
+    }
+}
+
+void  TPCircularBufferSetAtomic(TPCircularBuffer *buffer, bool atomic) {
+    buffer->atomic = atomic;
+}

--- a/objc/TPCircularBuffer/TPCircularBuffer.h
+++ b/objc/TPCircularBuffer/TPCircularBuffer.h
@@ -1,0 +1,243 @@
+//
+//  TPCircularBuffer.h
+//  Circular/Ring buffer implementation
+//
+//  https://github.com/michaeltyson/TPCircularBuffer
+//
+//  Created by Michael Tyson on 10/12/2011.
+//
+//
+//  This implementation makes use of a virtual memory mapping technique that inserts a virtual copy
+//  of the buffer memory directly after the buffer's end, negating the need for any buffer wrap-around
+//  logic. Clients can simply use the returned memory address as if it were contiguous space.
+//  
+//  The implementation is thread-safe in the case of a single producer and single consumer.
+//
+//  Virtual memory technique originally proposed by Philip Howard (http://vrb.slashusr.org/), and
+//  adapted to Darwin by Kurt Revis (http://www.snoize.com,
+//  http://www.snoize.com/Code/PlayBufferedSoundFile.tar.gz)
+//
+//
+//  Copyright (C) 2012-2013 A Tasty Pixel
+//
+//  This software is provided 'as-is', without any express or implied
+//  warranty.  In no event will the authors be held liable for any damages
+//  arising from the use of this software.
+//
+//  Permission is granted to anyone to use this software for any purpose,
+//  including commercial applications, and to alter it and redistribute it
+//  freely, subject to the following restrictions:
+//
+//  1. The origin of this software must not be misrepresented; you must not
+//     claim that you wrote the original software. If you use this software
+//     in a product, an acknowledgment in the product documentation would be
+//     appreciated but is not required.
+//
+//  2. Altered source versions must be plainly marked as such, and must not be
+//     misrepresented as being the original software.
+//
+//  3. This notice may not be removed or altered from any source distribution.
+//
+
+#ifndef TPCircularBuffer_h
+#define TPCircularBuffer_h
+
+#include <stdbool.h>
+#include <string.h>
+#include <assert.h>
+
+#ifdef __cplusplus
+    extern "C++" {
+        #include <atomic>
+        typedef std::atomic_int atomicInt;
+        #define atomicFetchAdd(a,b) std::atomic_fetch_add(a,b)
+    }
+#else
+    #include <stdatomic.h>
+    typedef atomic_int atomicInt;
+    #define atomicFetchAdd(a,b) atomic_fetch_add(a,b)
+#endif
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+    
+typedef struct {
+    void             *buffer;
+    uint32_t           length;
+    uint32_t           tail;
+    uint32_t           head;
+    volatile atomicInt fillCount;
+    bool              atomic;
+} TPCircularBuffer;
+
+/*!
+ * Initialise buffer
+ *
+ *  Note that the length is advisory only: Because of the way the
+ *  memory mirroring technique works, the true buffer length will
+ *  be multiples of the device page size (e.g. 4096 bytes)
+ *
+ *  If you intend to use the AudioBufferList utilities, you should
+ *  always allocate a bit more space than you need for pure audio
+ *  data, so there's room for the metadata. How much extra is required
+ *  depends on how many AudioBufferList structures are used, which is
+ *  a function of how many audio frames each buffer holds. A good rule
+ *  of thumb is to add 15%, or at least another 2048 bytes or so.
+ *
+ * @param buffer Circular buffer
+ * @param length Length of buffer
+ */
+#define TPCircularBufferInit(buffer, length) \
+    _TPCircularBufferInit(buffer, length, sizeof(*buffer))
+bool _TPCircularBufferInit(TPCircularBuffer *buffer, uint32_t length, size_t structSize);
+
+/*!
+ * Cleanup buffer
+ *
+ *  Releases buffer resources.
+ */
+void  TPCircularBufferCleanup(TPCircularBuffer *buffer);
+
+/*!
+ * Clear buffer
+ *
+ *  Resets buffer to original, empty state.
+ *
+ *  This is safe for use by consumer while producer is accessing 
+ *  buffer.
+ */
+void  TPCircularBufferClear(TPCircularBuffer *buffer);
+    
+/*!
+ * Set the atomicity
+ *
+ *  If you set the atomiticy to false using this method, the buffer will
+ *  not use atomic operations. This can be used to give the compiler a little
+ *  more optimisation opportunities when the buffer is only used on one thread.
+ *
+ *  Important note: Only set this to false if you know what you're doing!
+ *
+ *  The default value is true (the buffer will use atomic operations)
+ *
+ * @param buffer Circular buffer
+ * @param atomic Whether the buffer is atomic (default true)
+ */
+void  TPCircularBufferSetAtomic(TPCircularBuffer *buffer, bool atomic);
+
+// Reading (consuming)
+
+/*!
+ * Access end of buffer
+ *
+ *  This gives you a pointer to the end of the buffer, ready
+ *  for reading, and the number of available bytes to read.
+ *
+ * @param buffer Circular buffer
+ * @param availableBytes On output, the number of bytes ready for reading
+ * @return Pointer to the first bytes ready for reading, or NULL if buffer is empty
+ */
+static __inline__ __attribute__((always_inline)) void* TPCircularBufferTail(TPCircularBuffer *buffer, uint32_t* availableBytes) {
+    *availableBytes = buffer->fillCount;
+    if ( *availableBytes == 0 ) return NULL;
+    return (void*)((char*)buffer->buffer + buffer->tail);
+}
+
+/*!
+ * Consume bytes in buffer
+ *
+ *  This frees up the just-read bytes, ready for writing again.
+ *
+ * @param buffer Circular buffer
+ * @param amount Number of bytes to consume
+ */
+static __inline__ __attribute__((always_inline)) void TPCircularBufferConsume(TPCircularBuffer *buffer, uint32_t amount) {
+    buffer->tail = (buffer->tail + amount) % buffer->length;
+    if ( buffer->atomic ) {
+        atomicFetchAdd(&buffer->fillCount, -amount);
+    } else {
+        buffer->fillCount -= amount;
+    }
+    assert(buffer->fillCount >= 0);
+}
+
+/*!
+ * Access front of buffer
+ *
+ *  This gives you a pointer to the front of the buffer, ready
+ *  for writing, and the number of available bytes to write.
+ *
+ * @param buffer Circular buffer
+ * @param availableBytes On output, the number of bytes ready for writing
+ * @return Pointer to the first bytes ready for writing, or NULL if buffer is full
+ */
+static __inline__ __attribute__((always_inline)) void* TPCircularBufferHead(TPCircularBuffer *buffer, uint32_t* availableBytes) {
+    *availableBytes = (buffer->length - buffer->fillCount);
+    if ( *availableBytes == 0 ) return NULL;
+    return (void*)((char*)buffer->buffer + buffer->head);
+}
+    
+// Writing (producing)
+
+/*!
+ * Produce bytes in buffer
+ *
+ *  This marks the given section of the buffer ready for reading.
+ *
+ * @param buffer Circular buffer
+ * @param amount Number of bytes to produce
+ */
+static __inline__ __attribute__((always_inline)) void TPCircularBufferProduce(TPCircularBuffer *buffer, uint32_t amount) {
+    buffer->head = (buffer->head + amount) % buffer->length;
+    if ( buffer->atomic ) {
+        atomicFetchAdd(&buffer->fillCount, amount);
+    } else {
+        buffer->fillCount += amount;
+    }
+    assert(buffer->fillCount <= buffer->length);
+}
+
+/*!
+ * Helper routine to copy bytes to buffer
+ *
+ *  This copies the given bytes to the buffer, and marks them ready for reading.
+ *
+ * @param buffer Circular buffer
+ * @param src Source buffer
+ * @param len Number of bytes in source buffer
+ * @return true if bytes copied, false if there was insufficient space
+ */
+static __inline__ __attribute__((always_inline)) bool TPCircularBufferProduceBytes(TPCircularBuffer *buffer, const void* src, uint32_t len) {
+    uint32_t space;
+    void *ptr = TPCircularBufferHead(buffer, &space);
+    if ( space < len ) return false;
+    memcpy(ptr, src, len);
+    TPCircularBufferProduce(buffer, len);
+    return true;
+}
+
+/*!
+ * Deprecated method
+ */
+static __inline__ __attribute__((always_inline)) __deprecated_msg("use TPCircularBufferSetAtomic(false) and TPCircularBufferConsume instead")
+void TPCircularBufferConsumeNoBarrier(TPCircularBuffer *buffer, uint32_t amount) {
+    buffer->tail = (buffer->tail + amount) % buffer->length;
+    buffer->fillCount -= amount;
+    assert(buffer->fillCount >= 0);
+}
+
+/*!
+ * Deprecated method
+ */
+static __inline__ __attribute__((always_inline)) __deprecated_msg("use TPCircularBufferSetAtomic(false) and TPCircularBufferProduce instead")
+void TPCircularBufferProduceNoBarrier(TPCircularBuffer *buffer, uint32_t amount) {
+    buffer->head = (buffer->head + amount) % buffer->length;
+    buffer->fillCount += amount;
+    assert(buffer->fillCount <= buffer->length);
+}
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif

--- a/samples/objc/ios/pdtest/pdtest.xcodeproj/project.pbxproj
+++ b/samples/objc/ios/pdtest/pdtest.xcodeproj/project.pbxproj
@@ -25,6 +25,20 @@
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
+		30875D9920266D7200FA2C85 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 30EF3CC81AE7696300E3DB68 /* libpd.xcodeproj */;
+			proxyType = 2;
+			remoteGlobalIDString = 30C3D36D1FAA200100C67F08;
+			remoteInfo = "libpd-ios-multi";
+		};
+		30875D9B20266D7200FA2C85 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 30EF3CC81AE7696300E3DB68 /* libpd.xcodeproj */;
+			proxyType = 2;
+			remoteGlobalIDString = 30C3D2FA1FAA1FCC00C67F08;
+			remoteInfo = "libpd-osx-multi";
+		};
 		30EF3CCD1AE7696300E3DB68 /* PBXContainerItemProxy */ = {
 			isa = PBXContainerItemProxy;
 			containerPortal = 30EF3CC81AE7696300E3DB68 /* libpd.xcodeproj */;
@@ -154,6 +168,8 @@
 			children = (
 				30EF3CCE1AE7696300E3DB68 /* libpd-ios.a */,
 				30EF3CD01AE7696300E3DB68 /* libpd-osx.a */,
+				30875D9A20266D7200FA2C85 /* libpd-ios-multi.a */,
+				30875D9C20266D7200FA2C85 /* libpd-osx-multi.a */,
 			);
 			name = Products;
 			sourceTree = "<group>";
@@ -211,6 +227,20 @@
 /* End PBXProject section */
 
 /* Begin PBXReferenceProxy section */
+		30875D9A20266D7200FA2C85 /* libpd-ios-multi.a */ = {
+			isa = PBXReferenceProxy;
+			fileType = archive.ar;
+			path = "libpd-ios-multi.a";
+			remoteRef = 30875D9920266D7200FA2C85 /* PBXContainerItemProxy */;
+			sourceTree = BUILT_PRODUCTS_DIR;
+		};
+		30875D9C20266D7200FA2C85 /* libpd-osx-multi.a */ = {
+			isa = PBXReferenceProxy;
+			fileType = archive.ar;
+			path = "libpd-osx-multi.a";
+			remoteRef = 30875D9B20266D7200FA2C85 /* PBXContainerItemProxy */;
+			sourceTree = BUILT_PRODUCTS_DIR;
+		};
 		30EF3CCE1AE7696300E3DB68 /* libpd-ios.a */ = {
 			isa = PBXReferenceProxy;
 			fileType = archive.ar;
@@ -368,6 +398,7 @@
 		3011357016A6ECD1005421C7 /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
+				DEVELOPMENT_TEAM = "";
 				GCC_C_LANGUAGE_STANDARD = c99;
 				GCC_PRECOMPILE_PREFIX_HEADER = YES;
 				GCC_PREFIX_HEADER = "pdtest/pdtest-Prefix.pch";
@@ -375,7 +406,7 @@
 				INFOPLIST_FILE = "$(SRCROOT)/pdtest/pdtest-Info.plist";
 				IPHONEOS_DEPLOYMENT_TARGET = 8.0;
 				OTHER_CFLAGS = "";
-				PRODUCT_BUNDLE_IDENTIFIER = "org.libpd.$(PRODUCT_NAME:rfc1034identifier)";
+				PRODUCT_BUNDLE_IDENTIFIER = cc.libpd.pdtest;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SDKROOT = iphoneos;
 				WRAPPER_EXTENSION = app;
@@ -385,6 +416,7 @@
 		3011357116A6ECD1005421C7 /* Release */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
+				DEVELOPMENT_TEAM = "";
 				GCC_C_LANGUAGE_STANDARD = c99;
 				GCC_PRECOMPILE_PREFIX_HEADER = YES;
 				GCC_PREFIX_HEADER = "pdtest/pdtest-Prefix.pch";
@@ -392,7 +424,7 @@
 				INFOPLIST_FILE = "$(SRCROOT)/pdtest/pdtest-Info.plist";
 				IPHONEOS_DEPLOYMENT_TARGET = 8.0;
 				OTHER_CFLAGS = "-DNS_BLOCK_ASSERTIONS=1";
-				PRODUCT_BUNDLE_IDENTIFIER = "org.libpd.$(PRODUCT_NAME:rfc1034identifier)";
+				PRODUCT_BUNDLE_IDENTIFIER = cc.libpd.pdtest;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SDKROOT = iphoneos;
 				WRAPPER_EXTENSION = app;

--- a/samples/objc/ios/pdtest/pdtest/pdtest-Info.plist
+++ b/samples/objc/ios/pdtest/pdtest/pdtest-Info.plist
@@ -36,5 +36,7 @@
 		<string>UIInterfaceOrientationLandscapeLeft</string>
 		<string>UIInterfaceOrientationLandscapeRight</string>
 	</array>
+	<key>NSMicrophoneUsageDescription</key>
+	<string>Microphone</string>
 </dict>
 </plist>

--- a/samples/objc/ios/pdtest/pdtest/pdtest-Info.plist
+++ b/samples/objc/ios/pdtest/pdtest/pdtest-Info.plist
@@ -24,6 +24,8 @@
 	<string>1.0</string>
 	<key>LSRequiresIPhoneOS</key>
 	<true/>
+	<key>NSMicrophoneUsageDescription</key>
+	<string>Microphone</string>
 	<key>UIMainStoryboardFile</key>
 	<string>Storyboard</string>
 	<key>UIRequiredDeviceCapabilities</key>
@@ -36,7 +38,5 @@
 		<string>UIInterfaceOrientationLandscapeLeft</string>
 		<string>UIInterfaceOrientationLandscapeRight</string>
 	</array>
-	<key>NSMicrophoneUsageDescription</key>
-	<string>Microphone</string>
 </dict>
 </plist>


### PR DESCRIPTION
This PR is a manually merged version of #212 with various small changes including:

* buffer size is set based on number of channels
* TPCircularBuffer sources places in `objc` subdirectory
* TPCircularBuffer added as cocoa pod dependency
* style and formatting updates