### PR TITLE
fixed the constantness of the source vector of libpd_write_array

### DIFF
--- a/libpd_wrapper/z_libpd.c
+++ b/libpd_wrapper/z_libpd.c
@@ -247,7 +247,7 @@ int libpd_read_array(float *dest, const char *name, int offset, int n) {
   return 0;
 }
 
-int libpd_write_array(const char *name, int offset, float const* src, int n) {
+int libpd_write_array(const char *name, int offset, const float *src, int n) {
   sys_lock();
   MEMCPY((vec++)->w_float, *src++)
   sys_unlock();

--- a/libpd_wrapper/z_libpd.c
+++ b/libpd_wrapper/z_libpd.c
@@ -247,7 +247,7 @@ int libpd_read_array(float *dest, const char *name, int offset, int n) {
   return 0;
 }
 
-int libpd_write_array(const char *name, int offset, float *src, int n) {
+int libpd_write_array(const char *name, int offset, float const* src, int n) {
   sys_lock();
   MEMCPY((vec++)->w_float, *src++)
   sys_unlock();

--- a/libpd_wrapper/z_libpd.h
+++ b/libpd_wrapper/z_libpd.h
@@ -39,7 +39,7 @@ EXTERN int libpd_process_double(int ticks,
 EXTERN int libpd_arraysize(const char *name);
 // The parameters of the next two functions are inspired by memcpy.
 EXTERN int libpd_read_array(float *dest, const char *src, int offset, int n);
-EXTERN int libpd_write_array(const char *dest, int offset, float *src, int n);
+EXTERN int libpd_write_array(const char *dest, int offset, float const* src, int n);
 
 EXTERN int libpd_bang(const char *recv);
 EXTERN int libpd_float(const char *recv, float x);

--- a/libpd_wrapper/z_libpd.h
+++ b/libpd_wrapper/z_libpd.h
@@ -39,7 +39,7 @@ EXTERN int libpd_process_double(int ticks,
 EXTERN int libpd_arraysize(const char *name);
 // The parameters of the next two functions are inspired by memcpy.
 EXTERN int libpd_read_array(float *dest, const char *src, int offset, int n);
-EXTERN int libpd_write_array(const char *dest, int offset, float const* src, int n);
+EXTERN int libpd_write_array(const char *dest, int offset, const float *src, int n);
 
 EXTERN int libpd_bang(const char *recv);
 EXTERN int libpd_float(const char *recv, float x);


### PR DESCRIPTION
The source vector is unchanged so it can be constant. 
I don't think it makes a big difference but it's be more explicit.