### PR TITLE
On MSVC include windows.h to use synchronization functions

### DIFF
--- a/libpd_wrapper/util/ringbuffer.c
+++ b/libpd_wrapper/util/ringbuffer.c
@@ -26,6 +26,7 @@
     #define SYNC_COMPARE_AND_SWAP(ptr, oldval, newval) \
             OSAtomicCompareAndSwap32Barrier(oldval, newval, ptr)
   #elif defined(_WIN32) || defined(_WIN64) // win api atomics
+    #include <windows.h>
     #define SYNC_FETCH(ptr) InterlockedOr(ptr, 0)
     #define SYNC_COMPARE_AND_SWAP(ptr, oldval, newval) \
             InterlockedCompareExchange(ptr, oldval, newval)


### PR DESCRIPTION
On MSVC it is necessary to include `windows.h` in order to use the synchronization functions `InterlockedOr` and `InterlockedCompareExchange`.
Otherwise this would result in an unresolved external symbol linking error.
See here for more information:
https://msdn.microsoft.com/en-us/library/windows/desktop/ms683626(v=vs.85).aspx