### PR TITLE
Export symbols necessary when using libpd as shared library

### DIFF
--- a/libpd_wrapper/util/z_print_util.h
+++ b/libpd_wrapper/util/z_print_util.h
@@ -39,7 +39,7 @@ EXTERN void libpd_set_concatenated_printhook(const t_libpd_printhook hook);
 //       callback; if you intend to use the argument after the callback has 
 //       returned, you need to make a defensive copy.
 //
-void libpd_print_concatenator(const char *s);
+EXTERN void libpd_print_concatenator(const char *s);
 
 #ifdef __cplusplus
 }

--- a/libpd_wrapper/util/z_queued.h
+++ b/libpd_wrapper/util/z_queued.h
@@ -33,10 +33,10 @@ EXTERN void libpd_set_queued_aftertouchhook(const t_libpd_aftertouchhook hook);
 EXTERN void libpd_set_queued_polyaftertouchhook(const t_libpd_polyaftertouchhook hook);
 EXTERN void libpd_set_queued_midibytehook(const t_libpd_midibytehook hook);
 
-int libpd_queued_init();
-void libpd_queued_release();
-void libpd_queued_receive_pd_messages();
-void libpd_queued_receive_midi_messages();
+EXTERN int libpd_queued_init();
+EXTERN void libpd_queued_release();
+EXTERN void libpd_queued_receive_pd_messages();
+EXTERN void libpd_queued_receive_midi_messages();
 
 #ifdef __cplusplus
 }


### PR DESCRIPTION
When using libpd as a shared library on Windows there are a few symbols that are required when linking against it. These should be exported, otherwise linking is not possible.