### PR TITLE
fixed the constantness of int tick of libpd_process functions

### DIFF
--- a/libpd_wrapper/z_libpd.c
+++ b/libpd_wrapper/z_libpd.c
@@ -208,15 +208,15 @@ static const t_sample sample_to_short = SHRT_MAX,
   sys_unlock(); \
   return 0;
 
-int libpd_process_short(int ticks, const short *inBuffer, short *outBuffer) {
+int libpd_process_short(const int ticks, const short *inBuffer, short *outBuffer) {
   PROCESS(* short_to_sample, * sample_to_short)
 }
 
-int libpd_process_float(int ticks, const float *inBuffer, float *outBuffer) {
+int libpd_process_float(const int ticks, const float *inBuffer, float *outBuffer) {
   PROCESS(,)
 }
 
-int libpd_process_double(int ticks, const double *inBuffer, double *outBuffer) {
+int libpd_process_double(const int ticks, const double *inBuffer, double *outBuffer) {
   PROCESS(,)
 }
  

--- a/libpd_wrapper/z_libpd.h
+++ b/libpd_wrapper/z_libpd.h
@@ -31,9 +31,9 @@ EXTERN int libpd_init_audio(int inChans, int outChans, int sampleRate);
 EXTERN int libpd_process_raw(const float *inBuffer, float *outBuffer);
 EXTERN int libpd_process_short(const int ticks,
     const short *inBuffer, short *outBuffer);
-EXTERN int libpd_process_float(int ticks,
+EXTERN int libpd_process_float(const int ticks,
     const float *inBuffer, float *outBuffer);
-EXTERN int libpd_process_double(int ticks,
+EXTERN int libpd_process_double(const int ticks,
     const double *inBuffer, double *outBuffer);
 
 EXTERN int libpd_arraysize(const char *name);


### PR DESCRIPTION
In z_libpd.h, `int tick` of `libpd_process_short()` was declared with **const** (L. 32) but in z_libpd.c, `int tick` was not declared with **const** (L. 231) so it fix this. And the commit also add **const** to `libpd_process_float()` and `libpd_process_double()`.

FYI: In C, the declaration of the arguments doesn't break the backward compatibility so you can merge the PR without breaking anything (see [this](https://github.com/pure-data/pure-data/pull/256#issuecomment-348193147)).