### PR TITLE
update makefile for Windows to allow externals to load properly

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -37,6 +37,7 @@ samples/csharp/**/obj/*
 samples/csharp/**/bin/*
 csharp/obj/*
 csharp/bin/*
+libs/pd.*
 libs/libpd.*
 libs/libpdnative.*
 libs/libpdcsharp.*

--- a/Makefile
+++ b/Makefile
@@ -24,11 +24,11 @@ else
     PDNATIVE_ARCH = $(shell $(CC) -dumpmachine | sed -e 's,-.*,,' -e 's,i[3456]86,x86,' -e 's,amd64,x86_64,')
     PLATFORM_CFLAGS = -DWINVER=0x502 -DWIN32 -D_WIN32 -DPD_INTERNAL \
       -I"$(JAVA_HOME)/include" -I"$(JAVA_HOME)/include/win32"
-    MINGW_LDFLAGS = -shared -Wl,--export-all-symbols -lws2_32 -lkernel32
+    MINGW_LDFLAGS = -shared -Wl,--export-all-symbols -lws2_32 -lkernel32 -static-libgcc
     LDFLAGS = $(MINGW_LDFLAGS) -Wl,--output-def=$(LIBPD_DEF) \
       -Wl,--out-implib=$(LIBPD_IMPLIB)
     CSHARP_LDFLAGS = $(MINGW_LDFLAGS) -Wl,--output-def=libs/libpdcsharp.def \
-      -static-libgcc -Wl,--out-implib=libs/libpdcsharp.lib
+      -Wl,--out-implib=libs/libpdcsharp.lib
     JAVA_LDFLAGS = $(MINGW_LDFLAGS) -Wl,--kill-at
   else  # Linux or *BSD
     SOLIB_EXT = so

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,7 @@
 UNAME = $(shell uname)
 SOLIB_PREFIX = lib
+LIBPD_IMPLIB =
+LIBPD_DEF =
 
 ifeq ($(UNAME), Darwin)  # Mac
   SOLIB_EXT = dylib
@@ -16,13 +18,15 @@ else
     CC = gcc
     SOLIB_EXT = dll
     SOLIB_PREFIX =
+    LIBPD_IMPLIB = libs/libpd.lib
+    LIBPD_DEF = libs/libpd.def
     PDNATIVE_PLATFORM = windows
     PDNATIVE_ARCH = $(shell $(CC) -dumpmachine | sed -e 's,-.*,,' -e 's,i[3456]86,x86,' -e 's,amd64,x86_64,')
     PLATFORM_CFLAGS = -DWINVER=0x502 -DWIN32 -D_WIN32 -DPD_INTERNAL \
       -I"$(JAVA_HOME)/include" -I"$(JAVA_HOME)/include/win32"
     MINGW_LDFLAGS = -shared -Wl,--export-all-symbols -lws2_32 -lkernel32
-    LDFLAGS = $(MINGW_LDFLAGS) -Wl,--output-def=libs/libpd.def \
-      -Wl,--out-implib=libs/libpd.lib
+    LDFLAGS = $(MINGW_LDFLAGS) -Wl,--output-def=$(LIBPD_DEF) \
+      -Wl,--out-implib=$(LIBPD_IMPLIB)
     CSHARP_LDFLAGS = $(MINGW_LDFLAGS) -Wl,--output-def=libs/libpdcsharp.def \
       -static-libgcc -Wl,--out-implib=libs/libpdcsharp.lib
     JAVA_LDFLAGS = $(MINGW_LDFLAGS) -Wl,--kill-at
@@ -164,7 +168,11 @@ libdir ?= $(prefix)/lib
 JNI_FILE = libpd_wrapper/util/ringbuffer.c libpd_wrapper/util/z_queued.c $(JNI_SOUND)
 JNIH_FILE = jni/z_jni.h
 JAVA_BASE = java/org/puredata/core/PdBase.java
-LIBPD = libs/libpd.$(SOLIB_EXT)
+ifeq ($(OS), Windows_NT)
+	LIBPD = libs/pd.$(SOLIB_EXT)
+else
+	LIBPD = libs/libpd.$(SOLIB_EXT)
+endif
 PDCSHARP = libs/libpdcsharp.$(SOLIB_EXT)
 
 PDJAVA_BUILD = java-build
@@ -222,7 +230,7 @@ clean:
 	rm -f ${UTIL_FILES:.c=.o} ${PD_EXTRA_FILES:.c=.o}
 
 clobber: clean
-	rm -f $(LIBPD) ${LIBPD:.$(SOLIB_EXT)=.lib} ${LIBPD:.$(SOLIB_EXT)=.def}
+	rm -f $(LIBPD) $(LIBPD_IMPLIB) $(LIBPD_DEF)
 	rm -f $(PDCSHARP) ${PDCSHARP:.$(SOLIB_EXT)=.lib} ${PDCSHARP:.$(SOLIB_EXT)=.def}
 	rm -f $(PDJAVA_JAR) $(PDJAVA_NATIVE) libs/`basename $(PDJAVA_NATIVE)`
 	rm -rf $(PDJAVA_BUILD) $(PDJAVA_SRC) $(PDJAVA_DOC)
@@ -240,9 +248,9 @@ install:
 	fi
 	install -d $(libdir)
 	install -m 755 $(LIBPD) $(libdir)
-	if [ -e ${LIBPD:.$(SOLIB_EXT)=.def} ]; then install -m 755 ${LIBPD:.$(SOLIB_EXT)=.def} $(libdir); fi
-	if [ -e ${LIBPD:.$(SOLIB_EXT)=.lib} ]; then install -m 755 ${LIBPD:.$(SOLIB_EXT)=.lib} $(libdir); fi
+	if [ -e $(LIBPD_IMPLIB) ]; then install -m 755 $(LIBPD_IMPLIB) $(libdir); fi
+	if [ -e $(LIBPD_DEF) ]; then install -m 755 $(LIBPD_DEF) $(libdir); fi
 
 uninstall:
 	rm -rf $(includedir)/libpd
-	rm -f $(libdir)/`basename $(LIBPD)`
+	rm -f $(libdir)/`basename $(LIBPD)` $(libdir)/`basename $(LIBPD_IMPLIB)` $(libdir)/`basename $(LIBPD_DEF)`


### PR DESCRIPTION
right now, MinGW builds a "libpd.dll" on Windows. unfortunately, Pd externals in Windows are implicitly linked against a "pd.dll" and therefore either
A) simply won't load or 
B) crash the app if a "pd.dll" is in your system path because then Pd gets loaded twice, leading to all sorts of mayhem.

by changing the makefile to build a "pd.dll", externals will load fine. it's possible to keep the name of "libpd.lib" (and "libpd.def"), but I don't know if it's a good idea:
on the one hand it's a bit inconsistent for the import library to have a different name than the DLL, 
on the other hand you can simply do  "-lpd" with GCC on all systems.
I made two makefile variables for those files so it's easy to change them.
A third solution would be to output a pd.lib and simply make a copy named libpd.a. (this is what I actually did for the Pd build system so that we can link the extra externals with "-lpd" on all platforms).

Note: MinGW build scripts for user apps which directly link against "libpd.dll" would have to be adapted either way.

I also thought, "-static-libgcc" should go the MINGW_LDFLAGS, or is there a reason to only do it for C# builds? 