### PR TITLE
Makefile: Fix 'install' target when LIBPD_IMPLIB is empty.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -248,8 +248,8 @@ install:
 	fi
 	install -d $(libdir)
 	install -m 755 $(LIBPD) $(libdir)
-	if [ -e $(LIBPD_IMPLIB) ]; then install -m 755 $(LIBPD_IMPLIB) $(libdir); fi
-	if [ -e $(LIBPD_DEF) ]; then install -m 755 $(LIBPD_DEF) $(libdir); fi
+	if [ -e '$(LIBPD_IMPLIB)' ]; then install -m 755 $(LIBPD_IMPLIB) $(libdir); fi
+	if [ -e '$(LIBPD_DEF)' ]; then install -m 755 $(LIBPD_DEF) $(libdir); fi
 
 uninstall:
 	rm -rf $(includedir)/libpd


### PR DESCRIPTION
Hello, dear developers of libpd.  When `LIBPD_IMPLIB` or `LIBPD_DEF` is empty, the install target in Makefile will fail with:
```
install: missing desination file operand after '......'
Try 'install --help' for more information.
```

That's because `if [ -e ]; then echo no; fi` will print `no`...