### PR TITLE
fixed zip path traversal vulnerability

### DIFF
--- a/java/org/puredata/core/utils/IoUtils.java
+++ b/java/org/puredata/core/utils/IoUtils.java
@@ -80,14 +80,15 @@ public class IoUtils {
     List<File> files = new ArrayList<File>();
     ZipEntry entry;
     directory.mkdirs();
+    String canonicalRoot = directory.getCanonicalPath();
     while ((entry = zin.getNextEntry()) != null) {
       File file = new File(directory, entry.getName());
-      if (!file.getCanonicalPath().startsWith(directory.getCanonicalPath())) {
+      if (!file.getCanonicalPath().startsWith(canonicalRoot)) {
         // Ref: https://support.google.com/faqs/answer/9294009
         throw new SecurityException("Zip Path Traversal Vulnerability: " +
                     "Zip entry " + entry.getName() + " has " + 
                     file.getCanonicalPath() + " as its target path. " + 
-                    "But it should not be outside target dir " + directory.getCanonicalPath());
+                    "But it should not be outside target dir " + canonicalRoot);
       }
       
       files.add(file);

--- a/java/org/puredata/core/utils/IoUtils.java
+++ b/java/org/puredata/core/utils/IoUtils.java
@@ -57,6 +57,7 @@ public class IoUtils {
    * @param directory target directory
    * @return list of files that were unpacked, not including files that existed before
    * @throws IOException
+   * @throws SecurityException if zip resource has Path Traversal Vulnerability
    */
   public static List<File> extractZipResource(InputStream in, File directory) throws IOException {
     return extractZipResource(in, directory, false);
@@ -71,6 +72,7 @@ public class IoUtils {
    * @return list of files that were unpacked (if overwrite is false, this list won't include files
    *         that existed before)
    * @throws IOException
+   * @throws SecurityException if zip resource has Path Traversal Vulnerability
    */
   public static List<File> extractZipResource(InputStream in, File directory, boolean overwrite)
       throws IOException {

--- a/java/org/puredata/core/utils/IoUtils.java
+++ b/java/org/puredata/core/utils/IoUtils.java
@@ -82,6 +82,14 @@ public class IoUtils {
     directory.mkdirs();
     while ((entry = zin.getNextEntry()) != null) {
       File file = new File(directory, entry.getName());
+      if (!file.getCanonicalPath().startsWith(directory.getCanonicalPath())) {
+        // Ref: https://support.google.com/faqs/answer/9294009
+        throw new SecurityException("Zip Path Traversal Vulnerability: " +
+                    "Zip entry " + entry.getName() + " has " + 
+                    file.getCanonicalPath() + " as its target path. " + 
+                    "But it should not be outside target dir " + directory.getCanonicalPath());
+      }
+      
       files.add(file);
       if (overwrite || !file.exists()) {
         if (entry.isDirectory()) {


### PR DESCRIPTION
Fixes #266

## Testing

Manually tested copy of `extractZipResource` static method in our app. Yet to verify if Google Play console still throws the security alert.


