### PR TITLE
small build fixes

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,2 @@
+.git*      	export-ignore
+.travis.yml	export-ignore

--- a/.gitmodules
+++ b/.gitmodules
@@ -3,4 +3,4 @@
 	url = git://github.com/nettoyeurny/opensl_stream.git
 [submodule "pure-data"]
 	path = pure-data
-	url = git://git.code.sf.net/p/pure-data/pure-data
+	url = git://github.com/pure-data/pure-data

--- a/Makefile
+++ b/Makefile
@@ -189,8 +189,10 @@ PDJAVA_JAR = libs/libpd.jar
 PDJAVA_SRC = libs/libpd-sources.jar
 PDJAVA_DOC = javadoc
 
-CFLAGS = -DPD -DHAVE_UNISTD_H -DUSEAPI_DUMMY -I./pure-data/src \
-         -I./libpd_wrapper -I./libpd_wrapper/util $(PLATFORM_CFLAGS) \
+CFLAGS = -DPD -DHAVE_UNISTD_H -DUSEAPI_DUMMY \
+         -I./libpd_wrapper -I./libpd_wrapper/util \
+         -I./pure-data/src \
+         $(PLATFORM_CFLAGS) \
          $(OPT_CFLAGS) $(EXTRA_CFLAGS) $(MULTI_CFLAGS) $(LOCALE_CFLAGS) \
          $(ADDITIONAL_CFLAGS)
 LDFLAGS += $(ADDITIONAL_LDFLAGS)

--- a/samples/c/pdtest/Makefile
+++ b/samples/c/pdtest/Makefile
@@ -27,7 +27,7 @@ CFLAGS = -I$(LIBPD_DIR)/pure-data/src -I$(LIBPD_DIR)/libpd_wrapper -O3
 
 $(TARGET): ${SRC_FILES:.c=.o} $(LIBPD)
 	gcc -o $(TARGET) $^ $(LIBPD)
-	if [ $(PLATFORM) == "mac" ]; then mkdir -p ./libs && cp $(LIBPD) ./libs; fi
+	if [ "$(PLATFORM)" = "mac" ]; then mkdir -p ./libs && cp $(LIBPD) ./libs; fi
 
 $(LIBPD):
 	cd $(LIBPD_DIR) && make
@@ -37,5 +37,5 @@ clean:
 
 clobber: clean
 	rm -f $(TARGET)
-	if [ $(PLATFORM) == "mac" ]; then rm -rf ./libs; fi
+	if [ "$(PLATFORM)" = "mac" ]; then rm -rf ./libs; fi
 	cd $(LIBPD_DIR) && make clobber

--- a/samples/c/pdtest_gui/Makefile
+++ b/samples/c/pdtest_gui/Makefile
@@ -28,7 +28,7 @@ CFLAGS = -I$(LIBPD_DIR)/pure-data/src -I$(LIBPD_DIR)/libpd_wrapper \
 
 $(TARGET): ${SRC_FILES:.c=.o} $(LIBPD)
 	gcc -o $(TARGET) $^ $(LIBPD) $(LDFLAGS)
-	if [ $(PLATFORM) == "mac" ]; then mkdir -p ./libs && cp $(LIBPD) ./libs; fi
+	if [ "$(PLATFORM)" = "mac" ]; then mkdir -p ./libs && cp $(LIBPD) ./libs; fi
 
 $(LIBPD):
 	cd $(LIBPD_DIR) && make ADDITIONAL_CFLAGS=-DPDINSTANCE
@@ -38,5 +38,5 @@ clean:
 
 clobber: clean
 	rm -f $(TARGET)
-	if [ $(PLATFORM) == "mac" ]; then rm -rf ./libs; fi
+	if [ "$(PLATFORM)" = "mac" ]; then rm -rf ./libs; fi
 	cd $(LIBPD_DIR) && make clobber

--- a/samples/c/pdtest_multi/Makefile
+++ b/samples/c/pdtest_multi/Makefile
@@ -27,7 +27,7 @@ CFLAGS = -I$(LIBPD_DIR)/pure-data/src -I$(LIBPD_DIR)/libpd_wrapper -O3
 
 $(TARGET): ${SRC_FILES:.c=.o} $(LIBPD)
 	gcc -o $(TARGET) $^ $(LIBPD) $(LDFLAGS)
-	if [ $(PLATFORM) == "mac" ]; then mkdir -p ./libs && cp $(LIBPD) ./libs; fi
+	if [ "$(PLATFORM)" = "mac" ]; then mkdir -p ./libs && cp $(LIBPD) ./libs; fi
 
 $(LIBPD):
 	cd ../../.. && make MULTI=true
@@ -37,5 +37,5 @@ clean:
 
 clobber: clean
 	rm -f $(TARGET)
-	if [ $(PLATFORM) == "mac" ]; then rm -rf ./libs; fi
+	if [ "$(PLATFORM)" = "mac" ]; then rm -rf ./libs; fi
 	cd $(LIBPD_DIR) && make clobber

--- a/samples/c/pdtest_thread/Makefile
+++ b/samples/c/pdtest_thread/Makefile
@@ -28,7 +28,7 @@ CFLAGS = -I$(LIBPD_DIR)/pure-data/src -I$(LIBPD_DIR)/libpd_wrapper -O3
 
 $(TARGET): ${SRC_FILES:.c=.o} $(LIBPD)
 	gcc -o $(TARGET) $^ $(LIBPD) $(LDFLAGS)
-	if [ $(PLATFORM) == "mac" ]; then mkdir -p ./libs && cp $(LIBPD) ./libs; fi
+	if [ "$(PLATFORM)" = "mac" ]; then mkdir -p ./libs && cp $(LIBPD) ./libs; fi
 
 $(LIBPD):
 	cd ../../.. && make MULTI=true
@@ -38,5 +38,5 @@ clean:
 
 clobber: clean
 	rm -f $(TARGET)
-	if [ $(PLATFORM) == "mac" ]; then rm -rf ./libs; fi
+	if [ "$(PLATFORM)" = "mac" ]; then rm -rf ./libs; fi
 	cd $(LIBPD_DIR) && make clobber

--- a/samples/cpp/pdtest/Makefile
+++ b/samples/cpp/pdtest/Makefile
@@ -31,7 +31,7 @@ CXXFLAGS += -I$(LIBPD_DIR)/pure-data/src -I$(LIBPD_DIR)/libpd_wrapper \
 
 $(TARGET): ${SRC_FILES:.cpp=.o} $(LIBPD)
 	g++ -o $(TARGET) $^ $(LIBPD)
-	if [ $(PLATFORM) == "mac" ]; then mkdir -p ./libs && cp $(LIBPD) ./libs; fi
+	if [ "$(PLATFORM)" = "mac" ]; then mkdir -p ./libs && cp $(LIBPD) ./libs; fi
 
 $(LIBPD):
 	cd $(LIBPD_DIR) && make UTIL=true EXTRA=true
@@ -41,5 +41,5 @@ clean:
 
 clobber: clean
 	rm -f $(TARGET)
-	if [ $(PLATFORM) == "mac" ]; then rm -rf ./libs; fi
+	if [ "$(PLATFORM)" = "mac" ]; then rm -rf ./libs; fi
 	cd $(LIBPD_DIR) && make clobber

--- a/samples/cpp/pdtest_freeverb/Makefile
+++ b/samples/cpp/pdtest_freeverb/Makefile
@@ -38,7 +38,7 @@ CXXFLAGS += $(CFLAGS) -std=c++11 -DLIBPD_USE_STD_MUTEX
 
 $(TARGET): ${SRC_FILES:.cpp=.o} ${EXT_FILES:.c=.o} $(LIBPD)
 	g++ -o $(TARGET) $^ $(CXXFLAGS) $(LIBPD) $(AUDIO_API)
-	if [ $(PLATFORM) == "mac" ]; then mkdir -p ./libs && cp $(LIBPD) ./libs; fi
+	if [ "$(PLATFORM)" = "mac" ]; then mkdir -p ./libs && cp $(LIBPD) ./libs; fi
 
 $(LIBPD):
 	cd $(LIBPD_DIR) && make UTIL=true EXTRA=true
@@ -49,5 +49,5 @@ clean:
 
 clobber: clean
 	rm -f $(TARGET)
-	if [ $(PLATFORM) == "mac" ]; then rm -rf ./libs; fi
+	if [ "$(PLATFORM)" = "mac" ]; then rm -rf ./libs; fi
 	cd $(LIBPD_DIR) && make clobber

--- a/samples/cpp/pdtest_jack/Makefile
+++ b/samples/cpp/pdtest_jack/Makefile
@@ -40,7 +40,7 @@ CXXFLAGS = -I$(LIBPD_DIR)/pure-data/src -I$(LIBPD_DIR)/libpd_wrapper \
 
 $(TARGET): ${SRC_FILES:.cpp=.o} $(LIBPD)
 	g++ -o $(TARGET) $^ $(LIBPD) -ljack
-	if [ $(PLATFORM) == "mac" ]; then mkdir -p ./libs && cp $(LIBPD) ./libs; fi
+	if [ "$(PLATFORM)" = "mac" ]; then mkdir -p ./libs && cp $(LIBPD) ./libs; fi
 
 $(LIBPD):
 	cd $(LIBPD_DIR) && make UTIL=true EXTRA=true
@@ -50,5 +50,5 @@ clean:
 
 clobber: clean
 	rm -f $(TARGET)
-	if [ $(PLATFORM) == "mac" ]; then rm -rf ./libs; fi
+	if [ "$(PLATFORM)" = "mac" ]; then rm -rf ./libs; fi
 	cd $(LIBPD_DIR) && make clobber

--- a/samples/cpp/pdtest_rtaudio/Makefile
+++ b/samples/cpp/pdtest_rtaudio/Makefile
@@ -46,7 +46,7 @@ CXXFLAGS += -I$(LIBPD_DIR)/pure-data/src -I$(LIBPD_DIR)/libpd_wrapper \
 
 $(TARGET): ${SRC_FILES:.cpp=.o} $(LIBPD)
 	g++ -o $(TARGET) $^ $(LIBPD) $(AUDIO_API)
-	if [ $(PLATFORM) == "mac" ]; then mkdir -p ./libs && cp $(LIBPD) ./libs; fi
+	if [ "$(PLATFORM)" = "mac" ]; then mkdir -p ./libs && cp $(LIBPD) ./libs; fi
 
 $(LIBPD):
 	cd $(LIBPD_DIR) && make UTIL=true EXTRA=true
@@ -56,5 +56,5 @@ clean:
 
 clobber: clean
 	rm -f $(TARGET)
-	if [ $(PLATFORM) == "mac" ]; then rm -rf ./libs; fi
+	if [ "$(PLATFORM)" = "mac" ]; then rm -rf ./libs; fi
 	cd $(LIBPD_DIR) && make clobber


### PR DESCRIPTION
apart from the `.gitmodules` switch to github (which you might want to leave out if you don't agree with my "arguing" in #278 ), this PR contains a few minor build-system fixes:

- remove bashisms from various `Makefile`: 

  the POSIX-conformant way to check for string-equality uses a *single* `=` (two equal signs as in `==` is only valid in bash).

  even better would be to just use `make` conditionals....


- slight fixup in the main `Makefile`
  that moves the `-I./pure-data/src` flag *after* the include-flags for "libpd_wrapper/"; this makes sure to prefer files from "libpd_wrapper/" over files of the same name found in "puredata/src/" (e.g. when experimenting with a pure-data branch that includes libpd...

  if there are no files of the same-name in pure-data/src/ and libpd_wrapper/ (because pure-data has not included libpd), this change won't have any effect.