### PR TITLE
added array exists and resize

### DIFF
--- a/libpd_wrapper/z_libpd.c
+++ b/libpd_wrapper/z_libpd.c
@@ -223,15 +223,6 @@ int libpd_process_double(const int ticks, const double *inBuffer, double *outBuf
   t_garray *garray = (t_garray *) pd_findbyclass(gensym(name), garray_class); \
   if (!garray) {sys_unlock(); return -1;} \
 
-int libpd_arrayexists(const char *name) {
-  int retval;
-  sys_lock();
-  t_garray *garray = (t_garray *) pd_findbyclass(gensym(name), garray_class);
-  retval = (garray != NULL);
-  sys_unlock();
-  return retval;
-}
-
 int libpd_arraysize(const char *name) {
   int retval;
   sys_lock();

--- a/libpd_wrapper/z_libpd.c
+++ b/libpd_wrapper/z_libpd.c
@@ -223,6 +223,15 @@ int libpd_process_double(const int ticks, const double *inBuffer, double *outBuf
   t_garray *garray = (t_garray *) pd_findbyclass(gensym(name), garray_class); \
   if (!garray) {sys_unlock(); return -1;} \
 
+int libpd_arrayexists(const char *name) {
+  int retval;
+  sys_lock();
+  t_garray *garray = (t_garray *) pd_findbyclass(gensym(name), garray_class);
+  retval = (garray != NULL);
+  sys_unlock();
+  return retval;
+}
+
 int libpd_arraysize(const char *name) {
   int retval;
   sys_lock();
@@ -230,6 +239,14 @@ int libpd_arraysize(const char *name) {
   retval = garray_npoints(garray);
   sys_unlock();
   return retval;
+}
+
+int libpd_resize_array(const char *name, long size) {
+  sys_lock();
+  GETARRAY
+  garray_resize_long(garray, size);
+  sys_unlock();
+  return 0;
 }
 
 #define MEMCPY(_x, _y) \

--- a/libpd_wrapper/z_libpd.h
+++ b/libpd_wrapper/z_libpd.h
@@ -36,10 +36,6 @@ EXTERN int libpd_process_float(const int ticks,
 EXTERN int libpd_process_double(const int ticks,
     const double *inBuffer, double *outBuffer);
 
-/// check if an array with a given name exists
-/// returns 1 if the array exists, otherwise 0
-EXTERN int libpd_arrayexists(const char *name);
-
 EXTERN int libpd_arraysize(const char *name);
 
 /// (re)size an array by name; sizes <= 0 are clipped to 1

--- a/libpd_wrapper/z_libpd.h
+++ b/libpd_wrapper/z_libpd.h
@@ -36,7 +36,16 @@ EXTERN int libpd_process_float(const int ticks,
 EXTERN int libpd_process_double(const int ticks,
     const double *inBuffer, double *outBuffer);
 
+/// check if an array with a given name exists
+/// returns 1 if the array exists, otherwise 0
+EXTERN int libpd_arrayexists(const char *name);
+
 EXTERN int libpd_arraysize(const char *name);
+
+/// (re)size an array by name; sizes <= 0 are clipped to 1
+/// returns 0 on success or negative error code if non-existent
+EXTERN int libpd_resize_array(const char *name, long size);
+
 // The parameters of the next two functions are inspired by memcpy.
 EXTERN int libpd_read_array(float *dest, const char *src, int offset, int n);
 EXTERN int libpd_write_array(const char *dest, int offset, const float *src, int n);


### PR DESCRIPTION
This PR adds a couple functions to the C API to check if an array exists by name and to resize a given array.

Also, as garray_resize_long() takes a long argument, this makes me think if we should consider converting sizes argument types to size_t instead of int...