### PR TITLE
This fixes #287

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -240,8 +240,8 @@ endif()
 target_link_libraries(libpd PUBLIC ${CMAKE_THREAD_LIBS_INIT})
 
 if(NOT MSVC AND NOT APPLE)
-    find_library(MATH_LIB m)
-    target_link_libraries(libpd PUBLIC ${MATH_LIB})
+    find_library(M m)
+    target_link_libraries(libpd PUBLIC ${M_LIBRARIES})
 endif()
 
 if(PD_BUILD_C_EXAMPLES)


### PR DESCRIPTION
Fixing linkage of math library to target. (Issue occured on Ubuntu 18.04 with CMake 3.10.2)