### PR TITLE
Update podspec: requires_arc = true

### DIFF
--- a/libpd.podspec
+++ b/libpd.podspec
@@ -15,7 +15,7 @@ Pod::Spec.new do |spec|
                       'objc/**/*.{h,m}'
   spec.public_header_files = 'objc/**/*.{h}'
   spec.ios.deployment_target = '8.0'
-  spec.requires_arc = false
+  spec.requires_arc = true
   spec.frameworks = 'Foundation', 'AudioToolbox', 'AVFoundation'
   spec.compiler_flags = '-DPD', '-DUSEAPI_DUMMY', '-DHAVE_UNISTD_H', '-DLIBPD_EXTRA', '-fcommon'
   spec.exclude_files = 'pure-data/src/s_audio_alsa.h',


### PR DESCRIPTION
 Seems like the transition to ARC happened years ago (329c5a28af72e71d98b1a8cff923f715b8341bec), but the podspec hasn't been updated 