### PR TITLE
update `CMakelists.txt` with new file `s_net.c`

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -112,6 +112,7 @@ set(PD_SOURCES
     pure-data/src/s_inter.c
     pure-data/src/s_loader.c
     pure-data/src/s_main.c
+    pure-data/src/s_net.c
     pure-data/src/s_path.c
     pure-data/src/s_print.c
     pure-data/src/s_stuff.h


### PR DESCRIPTION
pure-data 0.51 added a new source file.

Fixes link problems with Emscripten <https://github.com/claudeha/pure-data/issues/5>