### PR TITLE
Change EXTERN to EXPORT in the wrapper's z headers

### DIFF
--- a/libpd_wrapper/util/z_print_util.h
+++ b/libpd_wrapper/util/z_print_util.h
@@ -27,7 +27,7 @@ extern "C"
 /// ie. line "hello 123" is sent in 3 parts -> "hello", " ", "123\n"
 
 /// assign the pointer to your print handler
-EXTERN void libpd_set_concatenated_printhook(const t_libpd_printhook hook);
+EXPORT void libpd_set_concatenated_printhook(const t_libpd_printhook hook);
 
 /// assign this function pointer to libpd_printhook or libpd_queued_printhook,
 /// depending on whether you're using queued messages, to intercept and
@@ -38,7 +38,7 @@ EXTERN void libpd_set_concatenated_printhook(const t_libpd_printhook hook);
 /// note: the char pointer argument is only good for the duration of the print
 ///       callback; if you intend to use the argument after the callback has
 ///       returned, you need to make a defensive copy
-EXTERN void libpd_print_concatenator(const char *s);
+EXPORT void libpd_print_concatenator(const char *s);
 
 #ifdef __cplusplus
 }

--- a/libpd_wrapper/util/z_queued.h
+++ b/libpd_wrapper/util/z_queued.h
@@ -20,70 +20,70 @@ extern "C"
 
 /// set the queued print receiver hook, NULL by default
 /// note: do not call this while DSP is running
-EXTERN void libpd_set_queued_printhook(const t_libpd_printhook hook);
+EXPORT void libpd_set_queued_printhook(const t_libpd_printhook hook);
 
 /// set the queued bang receiver hook, NULL by default
 /// note: do not call this while DSP is running
-EXTERN void libpd_set_queued_banghook(const t_libpd_banghook hook);
+EXPORT void libpd_set_queued_banghook(const t_libpd_banghook hook);
 
 /// set the queued float receiver hook, NULL by default
 /// note: do not call this while DSP is running
-EXTERN void libpd_set_queued_floathook(const t_libpd_floathook hook);
+EXPORT void libpd_set_queued_floathook(const t_libpd_floathook hook);
 
 /// set the queued symbol receiver hook, NULL by default
 /// note: do not call this while DSP is running
-EXTERN void libpd_set_queued_symbolhook(const t_libpd_symbolhook hook);
+EXPORT void libpd_set_queued_symbolhook(const t_libpd_symbolhook hook);
 
 /// set the queued list receiver hook, NULL by default
 /// note: do not call this while DSP is running
-EXTERN void libpd_set_queued_listhook(const t_libpd_listhook hook);
+EXPORT void libpd_set_queued_listhook(const t_libpd_listhook hook);
 
 /// set the queued typed message receiver hook, NULL by default
 /// note: do not call this while DSP is running
-EXTERN void libpd_set_queued_messagehook(const t_libpd_messagehook hook);
+EXPORT void libpd_set_queued_messagehook(const t_libpd_messagehook hook);
 
 /// set the queued MIDI note on hook, NULL by default
 /// note: do not call this while DSP is running
-EXTERN void libpd_set_queued_noteonhook(const t_libpd_noteonhook hook);
+EXPORT void libpd_set_queued_noteonhook(const t_libpd_noteonhook hook);
 
 /// set the queued MIDI control change hook, NULL by default
 /// note: do not call this while DSP is running
-EXTERN void libpd_set_queued_controlchangehook(const t_libpd_controlchangehook hook);
+EXPORT void libpd_set_queued_controlchangehook(const t_libpd_controlchangehook hook);
 
 /// set the queued MIDI program change hook, NULL by default
 /// note: do not call this while DSP is running
-EXTERN void libpd_set_queued_programchangehook(const t_libpd_programchangehook hook);
+EXPORT void libpd_set_queued_programchangehook(const t_libpd_programchangehook hook);
 
 /// set the queued MIDI pitch bend hook, NULL by default
 /// note: do not call this while DSP is running
-EXTERN void libpd_set_queued_pitchbendhook(const t_libpd_pitchbendhook hook);
+EXPORT void libpd_set_queued_pitchbendhook(const t_libpd_pitchbendhook hook);
 
 /// set the queued MIDI after touch hook, NULL by default
 /// note: do not call this while DSP is running
-EXTERN void libpd_set_queued_aftertouchhook(const t_libpd_aftertouchhook hook);
+EXPORT void libpd_set_queued_aftertouchhook(const t_libpd_aftertouchhook hook);
 
 /// set the queued MIDI poly after touch hook, NULL by default
 /// note: do not call this while DSP is running
-EXTERN void libpd_set_queued_polyaftertouchhook(const t_libpd_polyaftertouchhook hook);
+EXPORT void libpd_set_queued_polyaftertouchhook(const t_libpd_polyaftertouchhook hook);
 
 /// set the queued raw MIDI byte hook, NULL by default
 /// note: do not call this while DSP is running
-EXTERN void libpd_set_queued_midibytehook(const t_libpd_midibytehook hook);
+EXPORT void libpd_set_queued_midibytehook(const t_libpd_midibytehook hook);
 
 /// initialize libpd and the queued ringbuffers, use in place of libpd_init()
 /// this is safe to call more than once
 /// returns 0 on success, -1 if libpd was already initialized, or -2 if ring
 /// buffer allocation failed
-EXTERN int libpd_queued_init();
+EXPORT int libpd_queued_init();
 
 /// free the queued ringbuffers
-EXTERN void libpd_queued_release();
+EXPORT void libpd_queued_release();
 
 /// process and dispatch received messages in message ringbuffer
-EXTERN void libpd_queued_receive_pd_messages();
+EXPORT void libpd_queued_receive_pd_messages();
 
 /// process and dispatch receive midi messages in MIDI message ringbuffer
-EXTERN void libpd_queued_receive_midi_messages();
+EXPORT void libpd_queued_receive_midi_messages();
 
 #ifdef __cplusplus
 }

--- a/libpd_wrapper/z_libpd.h
+++ b/libpd_wrapper/z_libpd.h
@@ -19,50 +19,58 @@ extern "C"
 
 #include "m_pd.h"
 
+#ifndef EXPORT
+# ifdef BUILD_STATIC
+#  define EXPORT /* Leave blank: friendly with static linking */
+# else
+#  define EXPORT EXTERN
+# endif
+#endif
+
 /* initializing pd */
 
 /// initialize libpd; it is safe to call this more than once
 /// returns 0 on success or -1 if libpd was already initialized
 /// note: sets SIGFPE handler to keep bad pd patches from crashing due to divide
 ///       by 0, set any custom handling after calling this function
-EXTERN int libpd_init(void);
+EXPORT int libpd_init(void);
 
 /// clear the libpd search path for abstractions and externals
 /// note: this is called by libpd_init()
-EXTERN void libpd_clear_search_path(void);
+EXPORT void libpd_clear_search_path(void);
 
 /// add a path to the libpd search paths
 /// relative paths are relative to the current working directory
 /// unlike desktop pd, *no* search paths are set by default (ie. extra)
-EXTERN void libpd_add_to_search_path(const char *path);
+EXPORT void libpd_add_to_search_path(const char *path);
 
 /* opening patches */
 
 /// open a patch by filename and parent dir path
 /// returns an opaque patch handle pointer or NULL on failure
-EXTERN void *libpd_openfile(const char *name, const char *dir);
+EXPORT void *libpd_openfile(const char *name, const char *dir);
 
 /// close a patch by patch handle pointer
-EXTERN void libpd_closefile(void *p);
+EXPORT void libpd_closefile(void *p);
 
 /// get the $0 id of the patch handle pointer
 /// returns $0 value or 0 if the patch is non-existent
-EXTERN int libpd_getdollarzero(void *p);
+EXPORT int libpd_getdollarzero(void *p);
 
 /* audio processing */
 
 /// return pd's fixed block size: the number of sample frames per 1 pd tick
-EXTERN int libpd_blocksize(void);
+EXPORT int libpd_blocksize(void);
 
 /// initialize audio rendering
 /// returns 0 on success
-EXTERN int libpd_init_audio(int inChannels, int outChannels, int sampleRate);
+EXPORT int libpd_init_audio(int inChannels, int outChannels, int sampleRate);
 
 /// process interleaved float samples from inBuffer -> libpd -> outBuffer
 /// buffer sizes are based on # of ticks and channels where:
 ///     size = ticks * libpd_blocksize() * (in/out)channels
 /// returns 0 on success
-EXTERN int libpd_process_float(const int ticks,
+EXPORT int libpd_process_float(const int ticks,
     const float *inBuffer, float *outBuffer);
 
 /// process interleaved short samples from inBuffer -> libpd -> outBuffer
@@ -72,14 +80,14 @@ EXTERN int libpd_process_float(const int ticks,
 /// so any values received from pd patches beyond -1 to 1 will result in garbage
 /// note: for efficiency, does *not* clip input
 /// returns 0 on success
-EXTERN int libpd_process_short(const int ticks,
+EXPORT int libpd_process_short(const int ticks,
     const short *inBuffer, short *outBuffer);
 
 /// process interleaved double samples from inBuffer -> libpd -> outBuffer
 /// buffer sizes are based on # of ticks and channels where:
 ///     size = ticks * libpd_blocksize() * (in/out)channels
 /// returns 0 on success
-EXTERN int libpd_process_double(const int ticks,
+EXPORT int libpd_process_double(const int ticks,
     const double *inBuffer, double *outBuffer);
 
 /// process non-interleaved float samples from inBuffer -> libpd -> outBuffer
@@ -87,7 +95,7 @@ EXTERN int libpd_process_double(const int ticks,
 /// buffer sizes are based on a single tick and # of channels where:
 ///     size = libpd_blocksize() * (in/out)channels
 /// returns 0 on success
-EXTERN int libpd_process_raw(const float *inBuffer, float *outBuffer);
+EXPORT int libpd_process_raw(const float *inBuffer, float *outBuffer);
 
 /// process non-interleaved short samples from inBuffer -> libpd -> outBuffer
 /// copies buffer contents to/from libpd without striping
@@ -97,36 +105,36 @@ EXTERN int libpd_process_raw(const float *inBuffer, float *outBuffer);
 /// so any values received from pd patches beyond -1 to 1 will result in garbage
 /// note: for efficiency, does *not* clip input
 /// returns 0 on success
-EXTERN int libpd_process_raw_short(const short *inBuffer, short *outBuffer);
+EXPORT int libpd_process_raw_short(const short *inBuffer, short *outBuffer);
 
 /// process non-interleaved double samples from inBuffer -> libpd -> outBuffer
 /// copies buffer contents to/from libpd without striping
 /// buffer sizes are based on a single tick and # of channels where:
 ///     size = libpd_blocksize() * (in/out)channels
 /// returns 0 on success
-EXTERN int libpd_process_raw_double(const double *inBuffer, double *outBuffer);
+EXPORT int libpd_process_raw_double(const double *inBuffer, double *outBuffer);
 
 /* array access */
 
 /// get the size of an array by name
 /// returns size or negative error code if non-existent
-EXTERN int libpd_arraysize(const char *name);
+EXPORT int libpd_arraysize(const char *name);
 
 /// (re)size an array by name; sizes <= 0 are clipped to 1
 /// returns 0 on success or negative error code if non-existent
-EXTERN int libpd_resize_array(const char *name, long size);
+EXPORT int libpd_resize_array(const char *name, long size);
 
 /// read n values from named src array and write into dest starting at an offset
 /// note: performs no bounds checking on dest
 /// returns 0 on success or a negative error code if the array is non-existent
 /// or offset + n exceeds range of array
-EXTERN int libpd_read_array(float *dest, const char *name, int offset, int n);
+EXPORT int libpd_read_array(float *dest, const char *name, int offset, int n);
 
 /// read n values from src and write into named dest array starting at an offset
 /// note: performs no bounds checking on src
 /// returns 0 on success or a negative error code if the array is non-existent
 /// or offset + n exceeds range of array
-EXTERN int libpd_write_array(const char *name, int offset,
+EXPORT int libpd_write_array(const char *name, int offset,
 	const float *src, int n);
 
 /* sending messages to pd */
@@ -134,17 +142,17 @@ EXTERN int libpd_write_array(const char *name, int offset,
 /// send a bang to a destination receiver
 /// ex: libpd_bang("foo") will send a bang to [s foo] on the next tick
 /// returns 0 on success or -1 if receiver name is non-existent
-EXTERN int libpd_bang(const char *recv);
+EXPORT int libpd_bang(const char *recv);
 
 /// send a float to a destination receiver
 /// ex: libpd_float("foo", 1) will send a 1.0 to [s foo] on the next tick
 /// returns 0 on success or -1 if receiver name is non-existent
-EXTERN int libpd_float(const char *recv, float x);
+EXPORT int libpd_float(const char *recv, float x);
 
 /// send a symbol to a destination receiver
 /// ex: libpd_symbol("foo", "bar") will send "bar" to [s foo] on the next tick
 /// returns 0 on success or -1 if receiver name is non-existent
-EXTERN int libpd_symbol(const char *recv, const char *symbol);
+EXPORT int libpd_symbol(const char *recv, const char *symbol);
 
 /* sending compound messages: sequenced function calls */
 
@@ -152,13 +160,13 @@ EXTERN int libpd_symbol(const char *recv, const char *symbol);
 /// messages can be of a smaller length as max length is only an upper bound
 /// note: no cleanup is required for unfinished messages
 /// returns 0 on success or nonzero if the length is too large
-EXTERN int libpd_start_message(int maxlen);
+EXPORT int libpd_start_message(int maxlen);
 
 /// add a float to the current message in progress
-EXTERN void libpd_add_float(float x);
+EXPORT void libpd_add_float(float x);
 
 /// add a symbol to the current message in progress
-EXTERN void libpd_add_symbol(const char *symbol);
+EXPORT void libpd_add_symbol(const char *symbol);
 
 /// finish current message and send as a list to a destination receiver
 /// returns 0 on success or -1 if receiver name is non-existent
@@ -168,7 +176,7 @@ EXTERN void libpd_add_symbol(const char *symbol);
 ///     libpd_add_float(2);
 ///     libpd_add_symbol("bar");
 ///     libpd_finish_list("foo");
-EXTERN int libpd_finish_list(const char *recv);
+EXPORT int libpd_finish_list(const char *recv);
 
 /// finish current message and send as a typed message to a destination receiver
 /// note: typed message handling currently only supports up to 4 elements
@@ -178,15 +186,15 @@ EXTERN int libpd_finish_list(const char *recv);
 ///     libpd_start_message(1);
 ///     libpd_add_float(1);
 ///     libpd_finish_message("pd", "dsp");
-EXTERN int libpd_finish_message(const char *recv, const char *msg);
+EXPORT int libpd_finish_message(const char *recv, const char *msg);
 
 /* sending compound messages: atom array */
 
 /// write a float value to the given atom
-EXTERN void libpd_set_float(t_atom *a, float x);
+EXPORT void libpd_set_float(t_atom *a, float x);
 
 /// write a symbol value to the given atom
-EXTERN void libpd_set_symbol(t_atom *a, const char *symbol);
+EXPORT void libpd_set_symbol(t_atom *a, const char *symbol);
 
 /// send an atom array of a given length as a list to a destination receiver
 /// returns 0 on success or -1 if receiver name is non-existent
@@ -196,7 +204,7 @@ EXTERN void libpd_set_symbol(t_atom *a, const char *symbol);
 ///     libpd_set_float(v + 1, 2);
 ///     libpd_set_symbol(v + 2, "bar");
 ///     libpd_list("foo", 3, v);
-EXTERN int libpd_list(const char *recv, int argc, t_atom *argv);
+EXPORT int libpd_list(const char *recv, int argc, t_atom *argv);
 
 /// send a atom array of a given length as a typed message to a destination
 /// receiver, returns 0 on success or -1 if receiver name is non-existent
@@ -204,7 +212,7 @@ EXTERN int libpd_list(const char *recv, int argc, t_atom *argv);
 ///     t_atom v[1];
 ///     libpd_set_float(v, 1);
 ///     libpd_message("pd", "dsp", 1, v);
-EXTERN int libpd_message(const char *recv, const char *msg,
+EXPORT int libpd_message(const char *recv, const char *msg,
 	int argc, t_atom *argv);
 
 /* receiving messages from pd */
@@ -213,14 +221,14 @@ EXTERN int libpd_message(const char *recv, const char *msg,
 /// ex: libpd_bind("foo") adds a "virtual" [r foo] which forwards messages to
 ///     the libpd message hooks
 /// returns an opaque receiver pointer or NULL on failure
-EXTERN void *libpd_bind(const char *recv);
+EXPORT void *libpd_bind(const char *recv);
 
 /// unsubscribe and free a source receiver object created by libpd_bind()
-EXTERN void libpd_unbind(void *p);
+EXPORT void libpd_unbind(void *p);
 
 /// check if a source receiver object exists with a given name
 /// returns 1 if the receiver exists, otherwise 0
-EXTERN int libpd_exists(const char *recv);
+EXPORT int libpd_exists(const char *recv);
 
 /// print receive hook signature, s is the string to be printed
 /// note: default behavior returns individual words and spaces:
@@ -275,47 +283,47 @@ typedef void (*t_libpd_messagehook)(const char *recv, const char *msg,
 
 /// set the print receiver hook, prints to stdout by default
 /// note: do not call this while DSP is running
-EXTERN void libpd_set_printhook(const t_libpd_printhook hook);
+EXPORT void libpd_set_printhook(const t_libpd_printhook hook);
 
 /// set the bang receiver hook, NULL by default
 /// note: do not call this while DSP is running
-EXTERN void libpd_set_banghook(const t_libpd_banghook hook);
+EXPORT void libpd_set_banghook(const t_libpd_banghook hook);
 
 /// set the float receiver hook, NULL by default
 /// note: do not call this while DSP is running
-EXTERN void libpd_set_floathook(const t_libpd_floathook hook);
+EXPORT void libpd_set_floathook(const t_libpd_floathook hook);
 
 /// set the symbol receiver hook, NULL by default
 /// note: do not call this while DSP is running
-EXTERN void libpd_set_symbolhook(const t_libpd_symbolhook hook);
+EXPORT void libpd_set_symbolhook(const t_libpd_symbolhook hook);
 
 /// set the list receiver hook, NULL by default
 /// note: do not call this while DSP is running
-EXTERN void libpd_set_listhook(const t_libpd_listhook hook);
+EXPORT void libpd_set_listhook(const t_libpd_listhook hook);
 
 /// set the message receiver hook, NULL by default
 /// note: do not call this while DSP is running
-EXTERN void libpd_set_messagehook(const t_libpd_messagehook hook);
+EXPORT void libpd_set_messagehook(const t_libpd_messagehook hook);
 
 /// check if an atom is a float type: 0 or 1
 /// note: no NULL check is performed
-EXTERN int libpd_is_float(t_atom *a);
+EXPORT int libpd_is_float(t_atom *a);
 
 /// check if an atom is a symbol type: 0 or 1
 /// note: no NULL check is performed
-EXTERN int libpd_is_symbol(t_atom *a);
+EXPORT int libpd_is_symbol(t_atom *a);
 
 /// get the float value of an atom
 /// note: no NULL or type checks are performed
-EXTERN float libpd_get_float(t_atom *a);
+EXPORT float libpd_get_float(t_atom *a);
 
 /// note: no NULL or type checks are performed
 /// get symbol value of an atom
-EXTERN const char *libpd_get_symbol(t_atom *a);
+EXPORT const char *libpd_get_symbol(t_atom *a);
 
 /// increment to the next atom in an atom vector
 /// returns next atom or NULL, assuming the atom vector is NULL-terminated
-EXTERN t_atom *libpd_next_atom(t_atom *a);
+EXPORT t_atom *libpd_next_atom(t_atom *a);
 
 /* sending MIDI messages to pd */
 
@@ -324,53 +332,53 @@ EXTERN t_atom *libpd_next_atom(t_atom *a);
 /// channels encode MIDI ports via: libpd_channel = pd_channel + 16 * pd_port
 /// note: there is no note off message, send a note on with velocity = 0 instead
 /// returns 0 on success or -1 if an argument is out of range
-EXTERN int libpd_noteon(int channel, int pitch, int velocity);
+EXPORT int libpd_noteon(int channel, int pitch, int velocity);
 
 /// send a MIDI control change message to [ctlin] objects
 /// channel is 0-indexed, controller is 0-127, and value is 0-127
 /// channels encode MIDI ports via: libpd_channel = pd_channel + 16 * pd_port
 /// returns 0 on success or -1 if an argument is out of range
-EXTERN int libpd_controlchange(int channel, int controller, int value);
+EXPORT int libpd_controlchange(int channel, int controller, int value);
 
 /// send a MIDI program change message to [pgmin] objects
 /// channel is 0-indexed and value is 0-127
 /// channels encode MIDI ports via: libpd_channel = pd_channel + 16 * pd_port
 /// returns 0 on success or -1 if an argument is out of range
-EXTERN int libpd_programchange(int channel, int value);
+EXPORT int libpd_programchange(int channel, int value);
 
 /// send a MIDI pitch bend message to [bendin] objects
 /// channel is 0-indexed and value is -8192-8192
 /// channels encode MIDI ports via: libpd_channel = pd_channel + 16 * pd_port
 /// note: [bendin] outputs 0-16383 while [bendout] accepts -8192-8192
 /// returns 0 on success or -1 if an argument is out of range
-EXTERN int libpd_pitchbend(int channel, int value);
+EXPORT int libpd_pitchbend(int channel, int value);
 
 /// send a MIDI after touch message to [touchin] objects
 /// channel is 0-indexed and value is 0-127
 /// channels encode MIDI ports via: libpd_channel = pd_channel + 16 * pd_port
 /// returns 0 on success or -1 if an argument is out of range
-EXTERN int libpd_aftertouch(int channel, int value);
+EXPORT int libpd_aftertouch(int channel, int value);
 
 /// send a MIDI poly after touch message to [polytouchin] objects
 /// channel is 0-indexed, pitch is 0-127, and value is 0-127
 /// channels encode MIDI ports via: libpd_channel = pd_channel + 16 * pd_port
 /// returns 0 on success or -1 if an argument is out of range
-EXTERN int libpd_polyaftertouch(int channel, int pitch, int value);
+EXPORT int libpd_polyaftertouch(int channel, int pitch, int value);
 
 /// send a raw MIDI byte to [midiin] objects
 /// port is 0-indexed and byte is 0-256
 /// returns 0 on success or -1 if an argument is out of range
-EXTERN int libpd_midibyte(int port, int byte);
+EXPORT int libpd_midibyte(int port, int byte);
 
 /// send a raw MIDI byte to [sysexin] objects
 /// port is 0-indexed and byte is 0-256
 /// returns 0 on success or -1 if an argument is out of range
-EXTERN int libpd_sysex(int port, int byte);
+EXPORT int libpd_sysex(int port, int byte);
 
 /// send a raw MIDI byte to [realtimein] objects
 /// port is 0-indexed and byte is 0-256
 /// returns 0 on success or -1 if an argument is out of range
-EXTERN int libpd_sysrealtime(int port, int byte);
+EXPORT int libpd_sysrealtime(int port, int byte);
 
 /* receiving MIDI messages from pd */
 
@@ -420,37 +428,37 @@ typedef void (*t_libpd_midibytehook)(int port, int byte);
 
 /// set the MIDI note on hook to receive from [noteout] objects, NULL by default
 /// note: do not call this while DSP is running
-EXTERN void libpd_set_noteonhook(const t_libpd_noteonhook hook);
+EXPORT void libpd_set_noteonhook(const t_libpd_noteonhook hook);
 
 /// set the MIDI control change hook to receive from [ctlout] objects,
 /// NULL by default
 /// note: do not call this while DSP is running
-EXTERN void libpd_set_controlchangehook(const t_libpd_controlchangehook hook);
+EXPORT void libpd_set_controlchangehook(const t_libpd_controlchangehook hook);
 
 /// set the MIDI program change hook to receive from [pgmout] objects,
 /// NULL by default
 /// note: do not call this while DSP is running
-EXTERN void libpd_set_programchangehook(const t_libpd_programchangehook hook);
+EXPORT void libpd_set_programchangehook(const t_libpd_programchangehook hook);
 
 /// set the MIDI pitch bend hook to receive from [bendout] objects,
 /// NULL by default
 /// note: do not call this while DSP is running
-EXTERN void libpd_set_pitchbendhook(const t_libpd_pitchbendhook hook);
+EXPORT void libpd_set_pitchbendhook(const t_libpd_pitchbendhook hook);
 
 /// set the MIDI after touch hook to receive from [touchout] objects,
 /// NULL by default
 /// note: do not call this while DSP is running
-EXTERN void libpd_set_aftertouchhook(const t_libpd_aftertouchhook hook);
+EXPORT void libpd_set_aftertouchhook(const t_libpd_aftertouchhook hook);
 
 /// set the MIDI poly after touch hook to receive from [polytouchout] objects,
 /// NULL by default
 /// note: do not call this while DSP is running
-EXTERN void libpd_set_polyaftertouchhook(const t_libpd_polyaftertouchhook hook);
+EXPORT void libpd_set_polyaftertouchhook(const t_libpd_polyaftertouchhook hook);
 
 /// set the raw MIDI byte hook to receive from [midiout] objects,
 /// NULL by default
 /// note: do not call this while DSP is running
-EXTERN void libpd_set_midibytehook(const t_libpd_midibytehook hook);
+EXPORT void libpd_set_midibytehook(const t_libpd_midibytehook hook);
 
 /* GUI */
 
@@ -458,10 +466,10 @@ EXTERN void libpd_set_midibytehook(const t_libpd_midibytehook hook);
 /// requires the path to pd's main folder that contains bin/, tcl/, etc
 /// for a macOS .app bundle: /path/to/Pd-#.#-#.app/Contents/Resources
 /// returns 0 on success
-EXTERN int libpd_start_gui(const char *path);
+EXPORT int libpd_start_gui(const char *path);
 
 /// stop the pd vanilla GUI
-EXTERN void libpd_stop_gui(void);
+EXPORT void libpd_stop_gui(void);
 
 /// manually update and handle any GUI messages
 /// this is called automatically when using a libpd_process function,
@@ -469,42 +477,42 @@ EXTERN void libpd_stop_gui(void);
 ///       useful to call repeatedly when idle for more throughput
 ///       Returns 1 if the poll found something, in which case it might be
 ///       desirable to poll again, up to some reasonable limit.
-EXTERN int libpd_poll_gui(void);
+EXPORT int libpd_poll_gui(void);
 
 /* multiple instances */
 
 /// create a new pd instance
 /// returns new instance or NULL when libpd is not compiled with PDINSTANCE
-EXTERN t_pdinstance *libpd_new_instance(void);
+EXPORT t_pdinstance *libpd_new_instance(void);
 
 /// set the current pd instance
 /// subsequent libpd calls will affect this instance only
 /// does nothing when libpd is not compiled with PDINSTANCE
-EXTERN void libpd_set_instance(t_pdinstance *p);
+EXPORT void libpd_set_instance(t_pdinstance *p);
 
 /// free a pd instance
 /// does nothing when libpd is not compiled with PDINSTANCE
-EXTERN void libpd_free_instance(t_pdinstance *p);
+EXPORT void libpd_free_instance(t_pdinstance *p);
 
 /// get the current pd instance
-EXTERN t_pdinstance *libpd_this_instance(void);
+EXPORT t_pdinstance *libpd_this_instance(void);
 
 /// get a pd instance by index
 /// returns NULL if index is out of bounds or "this" instance when libpd is not
 /// compiled with PDINSTANCE
-EXTERN t_pdinstance *libpd_get_instance(int index);
+EXPORT t_pdinstance *libpd_get_instance(int index);
 
 /// get the number of pd instances
 /// returns number or 1 when libpd is not compiled with PDINSTANCE
-EXTERN int libpd_num_instances(void);
+EXPORT int libpd_num_instances(void);
 
 /* log level */
 
 /// set verbose print state: 0 or 1
-EXTERN void libpd_set_verbose(int verbose);
+EXPORT void libpd_set_verbose(int verbose);
 
 /// get the verbose print state: 0 or 1
-EXTERN int libpd_get_verbose(void);
+EXPORT int libpd_get_verbose(void);
 
 #ifdef __cplusplus
 }

--- a/libpd_wrapper/z_libpd.h
+++ b/libpd_wrapper/z_libpd.h
@@ -20,7 +20,7 @@ extern "C"
 #include "m_pd.h"
 
 #ifndef EXPORT
-# ifdef BUILD_STATIC
+# ifdef LIBPD_STATIC
 #  define EXPORT /* Leave blank: friendly with static linking */
 # else
 #  define EXPORT EXTERN

--- a/samples/cpp/pdtest/Makefile
+++ b/samples/cpp/pdtest/Makefile
@@ -40,7 +40,7 @@ ifeq ($(PLATFORM), mac)
 	mkdir -p ./libs && cp $(LIBPD) ./libs
 endif
 
-static: CXXFLAGS += -DBUILD_STATIC
+static: CXXFLAGS += -DLIBPD_STATIC
 static: ${SRC_FILES:.cpp=.o} $(LIBPD_DIR)/libs/libpd.a
 	g++ -o $(TARGET) $^ $(LDLIBS)
 

--- a/samples/cpp/pdtest/Makefile
+++ b/samples/cpp/pdtest/Makefile
@@ -10,33 +10,45 @@ ifeq ($(UNAME), Darwin) # Mac
 else
   ifeq ($(OS), Windows_NT) # Windows, use Mingw
     SOLIB_EXT = dll
-    SOLIB_PREFIX = 
+    SOLIB_PREFIX =
     PLATFORM = windows
+    LDLIBS = -Wl,--export-all-symbols -static-libgcc -lws2_32 -lkernel32
   else # assume Linux
     SOLIB_EXT = so
     PLATFORM = linux
+    ifeq ($(UNAME), Linux)
+      LDLIBS = -ldl
+    endif
   endif
 endif
 
 LIBPD_DIR = ../../..
-LIBPD = $(LIBPD_DIR)/libs/libpd.$(SOLIB_EXT)
+LIBPD = $(LIBPD_DIR)/libs/$(SOLIB_PREFIX)pd.$(SOLIB_EXT)
 
 SRC_FILES = src/PdObject.cpp src/main.cpp
 TARGET = pdtest
 
+LDLIBS += -lm -lpthread
 CXXFLAGS += -I$(LIBPD_DIR)/pure-data/src -I$(LIBPD_DIR)/libpd_wrapper \
             -I$(LIBPD_DIR)/libpd_wrapper/util -I$(LIBPD_DIR)/cpp -I./src -O3
 
-.PHONY: clean clobber
+.PHONY: clean clobber static
 
 $(TARGET): ${SRC_FILES:.cpp=.o} $(LIBPD)
-	g++ -o $(TARGET) $^ $(LIBPD)
+	g++ -o $(TARGET) $^
 ifeq ($(PLATFORM), mac)
 	mkdir -p ./libs && cp $(LIBPD) ./libs
 endif
 
+static: CXXFLAGS += -DBUILD_STATIC
+static: ${SRC_FILES:.cpp=.o} $(LIBPD_DIR)/libs/libpd.a
+	g++ -o $(TARGET) $^ $(LDLIBS)
+
 $(LIBPD):
 	cd $(LIBPD_DIR) && make UTIL=true EXTRA=true
+
+$(LIBPD_DIR)/libs/libpd.a:
+	cd $(LIBPD_DIR) && make UTIL=true EXTRA=true STATIC=true
 
 clean:
 	rm -f src/*.o


### PR DESCRIPTION
EXPORT will be blank if the user defines the macro BUILD_STATIC

This makes it so that MinGW can link to libpd statically,
whereas before, the linker would complain about there being
undefined references.

An example of its usage has been added to samples/cpp/pdtest, which can be tested with:
    `make static`