### PR TITLE
raised cmake version minimum a tiny notch

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required (VERSION 2.8.11)
+cmake_minimum_required (VERSION 2.8.12)
 project (libpd C)
 
 option(PD_UTILS  "Compile utilities" ON)


### PR DESCRIPTION
using CMake to compile libpd we get the following warning:

```
CMake Deprecation Warning at /libpd/CMakeLists.txt:1 (cmake_minimum_required):
  Compatibility with CMake < 2.8.12 will be removed from a future version of
  CMake.

  Update the VERSION argument <min> value or use a ...<max> suffix to tell
  CMake that the project does not need compatibility with older versions.
```

To get rid of this warning we change the line 1 of CMakeLists.txt from

`cmake_minimum_required (VERSION 2.8.11)`

to

`cmake_minimum_required (VERSION 2.8.12)`