### PR TITLE
libpd_add_to_help_path

### DIFF
--- a/libpd_wrapper/z_libpd.c
+++ b/libpd_wrapper/z_libpd.c
@@ -124,6 +124,12 @@ void libpd_add_to_search_path(const char *path) {
   sys_unlock();
 }
 
+void libpd_add_to_help_path(const char *path) {
+  sys_lock();
+  STUFF->st_helppath = namelist_append(STUFF->st_helppath, path, 0);
+  sys_unlock();
+}
+
 void *libpd_openfile(const char *name, const char *dir) {
   void *retval;
   sys_lock();

--- a/libpd_wrapper/z_libpd.h
+++ b/libpd_wrapper/z_libpd.h
@@ -36,6 +36,13 @@ EXTERN void libpd_clear_search_path(void);
 /// unlike desktop pd, *no* search paths are set by default (ie. extra)
 EXTERN void libpd_add_to_search_path(const char *path);
 
+/// add a path to the libpd help paths
+/// relative paths are relative to the current working directory
+/// this is triggered when calling help from pd gui.
+/// pd will search for files named <object name>-help.pd
+/// in linux typically that'd be /usr/lib/puredata/doc/5.reference
+EXTERN void libpd_add_to_help_path(const char *path);
+
 /* opening patches */
 
 /// open a patch by filename and parent dir path


### PR DESCRIPTION
While working with libpd (and launching the gui), I couldn't get use the help functions.
Now, by calling `libpd_add_to_help_path("/usr/lib/puredata/doc/5.reference")` (in linux) it works