### PR TITLE
Fixed build issues for Java

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -53,7 +53,7 @@ else
     ifeq ($(UNAME), Linux)
       PDNATIVE_PLATFORM = linux
       JAVA_HOME ?= /usr/lib/jvm/default-java
-      PLATFORM_CFLAGS += -I"$(JAVA_HOME)/include/linux" -DHAVE_LIBDL
+      PLATFORM_CFLAGS += -I"$(JAVA_HOME)/include/linux" -I"$(JAVA_HOME)/include" -DHAVE_LIBDL
       LDFLAGS += -ldl
     else ifeq ($(UNAME), FreeBSD)
       PDNATIVE_PLATFORM = FreeBSD
@@ -115,7 +115,7 @@ LIBPD_UTILS = \
 
 PDJAVA_JAR_CLASSES = \
     java/org/puredata/core/PdBase.java \
-    java/org/puredata/core/PdBaseloader.java \
+    java/org/puredata/core/PdBaseLoader.java \
     java/org/puredata/core/NativeLoader.java \
     java/org/puredata/core/PdListener.java \
     java/org/puredata/core/PdMidiListener.java \


### PR DESCRIPTION
* Fixed typo in one of the Java filenames
* Added path to `$(JAVA_HOME)/include` so that both jni.h and jni_md.h can be found.

On my Manjaro system JAVA_HOME is /usr/lib/jvm/default, but on Raspbian and I guess Ubuntu, it is /usr/lib/jvm/default-java, so that is probably a fairly shure shot.