### PR TITLE
Add a Rust section to the main README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -384,6 +384,16 @@ If you install pyaudio with `pip`, you will need to install Portaudio first. On 
 
     brew install portaudio
 
+
+Rust
+------
+
+There is currently a third party Rust wrapper for libpd called [libpd-rs](https://github.com/alisomay/libpd-rs) which is actively maintained.
+
+[libpd-rs](https://github.com/alisomay/libpd-rs) uses a [fork](https://github.com/alisomay/libpd/tree/libpdrs) of libpd which is frequently synchronized with upstream. 
+
+Please visit the [repository](https://github.com/alisomay/libpd-rs) for detailed information.
+
 Building with CMake
 -------------------
 


### PR DESCRIPTION
I've been working on a project to make libpd available in the Rust ecosystem. 

Currently it is published as [libpd-rs and libpd-sys](https://crates.io/search?q=libpd) where the former is for users and the latter is the raw bindings. 

It does not support multi instances yet, but the support will be there soon also. 

You may check the platform support [here](https://github.com/alisomay/libpd-rs#support).

If you also find it relevant, I'd love to list it in the main README.md.

Thanks to @danomatika for his support along the way.