### PR TITLE
Android.mk: declare libpd_wrapper headers before outdated pure-data ones

### DIFF
--- a/Android.mk
+++ b/Android.mk
@@ -39,8 +39,8 @@ PD_SRC_FILES := \
   libpd_wrapper/x_libpdreceive.c libpd_wrapper/z_libpd.c \
   libpd_wrapper/util/ringbuffer.c libpd_wrapper/util/z_queued.c \
   libpd_wrapper/z_hooks.c libpd_wrapper/util/z_print_util.c
-PD_C_INCLUDES := $(LOCAL_PATH)/pure-data/src $(LOCAL_PATH)/libpd_wrapper \
-  $(LOCAL_PATH)/libpd_wrapper/util
+PD_C_INCLUDES := $(LOCAL_PATH)/libpd_wrapper $(LOCAL_PATH)/libpd_wrapper/util \
+  $(LOCAL_PATH)/pure-data/src
 PD_CFLAGS := -DPD -DHAVE_UNISTD_H -DHAVE_LIBDL -DUSEAPI_DUMMY -w
 PD_JNI_CFLAGS := -Wno-int-to-pointer-cast -Wno-pointer-to-int-cast
 PD_LDLIBS := -ldl -latomic


### PR DESCRIPTION
This is untested, but there is a chance that  it could fix #356.

