### PR TITLE
Adding extra headers to install command

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -282,7 +282,6 @@ install:
 	install -m 644 pure-data/src/m_pd.h $(includedir)/libpd
 	install -m 644 pure-data/src/m_imp.h $(includedir)/libpd
 	install -m 644 pure-data/src/g_canvas.h $(includedir)/libpd
-	install -m 644 pure-data/src/s_utf8.h $(includedir)/libpd
 	if [ -e libpd_wrapper/util/z_queued.o ]; then \
 	  install -d $(includedir)/libpd/util; \
 	  install -m 644 libpd_wrapper/util/z_print_util.h $(includedir)/libpd/util; \

--- a/Makefile
+++ b/Makefile
@@ -280,6 +280,9 @@ install:
 	install -d $(includedir)/libpd
 	install -m 644 libpd_wrapper/z_libpd.h $(includedir)/libpd
 	install -m 644 pure-data/src/m_pd.h $(includedir)/libpd
+	install -m 644 pure-data/src/m_imp.h $(includedir)/libpd
+	install -m 644 pure-data/src/g_canvas.h $(includedir)/libpd
+	install -m 644 pure-data/src/s_utf8.h $(includedir)/libpd
 	if [ -e libpd_wrapper/util/z_queued.o ]; then \
 	  install -d $(includedir)/libpd/util; \
 	  install -m 644 libpd_wrapper/util/z_print_util.h $(includedir)/libpd/util; \


### PR DESCRIPTION
These extra header file installs add support for compiling in some externals that would not work otherwise, mainly the `cyclone` and `zexy` externals.

With this change, a libpd user can add the C source for cyclone and zexy straight into their program, without needing to go through hoops compiling a separate external - and this is useful in situations where libpd is not expected to load any precompiled externals at runtime, such as when the CPU architecture is not explicitly supported. The particular case that spawned this request was when compiling libpd for an app in Linux for a MIPS4k processor.