### PR TITLE
cpp: address level 3 warnings

### DIFF
--- a/cpp/PdBase.hpp
+++ b/cpp/PdBase.hpp
@@ -820,7 +820,7 @@ public:
 ///
 
     /// start a compound message
-    PdBase& operator<<(const pd::StartMessage &var) {
+    PdBase& operator<<(const pd::StartMessage &) {
         startMessage();
         return *this;
     }
@@ -984,7 +984,7 @@ public:
     }
 
     /// finish and send a raw byte MIDI message
-    PdBase& operator<<(const pd::Finish &var) {
+    PdBase& operator<<(const pd::Finish &) {
         if(!bMsgInProgress) {
             std::cerr << "Pd: cannot finish midi byte stream, "
                       << "stream not in progress" << std::endl;
@@ -1072,7 +1072,7 @@ public:
             return false;
         }
         // resize if necessary
-        if(dest.size() != readLen) {
+        if(dest.size() != (std::size_t)readLen) {
             dest.resize(readLen, 0);
         }
         if(libpd_read_array(&dest[0], name.c_str(), offset, readLen) < 0) {

--- a/cpp/PdMidiReceiver.hpp
+++ b/cpp/PdMidiReceiver.hpp
@@ -23,32 +23,32 @@ public:
     virtual ~PdMidiReceiver() {}
 
     /// receive a MIDI note on
-    virtual void receiveNoteOn(const int channel,
-                               const int pitch,
-                               const int velocity) {}
+    virtual void receiveNoteOn(const int /*channel*/,
+                               const int /*pitch*/,
+                               const int /*velocity*/) {}
 
     /// receive a MIDI control change
-    virtual void receiveControlChange(const int channel,
-                                      const int controller,
-                                      const int value) {}
+    virtual void receiveControlChange(const int /*channel*/,
+                                      const int /*controller*/,
+                                      const int /*value*/) {}
 
     /// receive a MIDI program change,
     /// note: pgm value is 1-128
-    virtual void receiveProgramChange(const int channel, const int value) {}
+    virtual void receiveProgramChange(const int /*channel*/, const int /*value*/) {}
 
     /// receive a MIDI pitch bend
-    virtual void receivePitchBend(const int channel, const int value) {}
+    virtual void receivePitchBend(const int /*channel*/, const int /*value*/) {}
 
     /// receive a MIDI aftertouch message
-    virtual void receiveAftertouch(const int channel, const int value) {}
+    virtual void receiveAftertouch(const int /*channel*/, const int /*value*/) {}
 
     /// receive a MIDI poly aftertouch message
-    virtual void receivePolyAftertouch(const int channel,
-                                       const int pitch,
-                                       const int value) {}
+    virtual void receivePolyAftertouch(const int /*channel*/,
+                                       const int /*pitch*/,
+                                       const int /*value*/) {}
 
     /// receive a raw MIDI byte (sysex, realtime, etc)
-    virtual void receiveMidiByte(const int port, const int byte) {}
+    virtual void receiveMidiByte(const int /*port*/, const int /*byte*/) {}
 };
 
 } // namespace

--- a/cpp/PdReceiver.hpp
+++ b/cpp/PdReceiver.hpp
@@ -25,26 +25,26 @@ public:
     virtual ~PdReceiver() {}
 
     /// receive a print
-    virtual void print(const std::string &message) {}
+    virtual void print(const std::string &/*message*/) {}
 
     /// receive a bang
-    virtual void receiveBang(const std::string &dest) {}
+    virtual void receiveBang(const std::string &/*dest*/) {}
 
     /// receive a float
-    virtual void receiveFloat(const std::string &dest, float num) {}
+    virtual void receiveFloat(const std::string &/*dest*/, float /*num*/) {}
 
     /// receive a symbol
-    virtual void receiveSymbol(const std::string &dest,
-                               const std::string& symbol) {}
+    virtual void receiveSymbol(const std::string &/*dest*/,
+                               const std::string &/*symbol*/) {}
 
     /// receive a list
-    virtual void receiveList(const std::string &dest, const pd::List& list) {}
+    virtual void receiveList(const std::string &/*dest*/, const pd::List &/*list*/) {}
 
     /// receive a named message ie. sent from a message box like:
     /// [; dest msg arg1 arg2 arg3(
-    virtual void receiveMessage(const std::string &dest,
-                                const std::string &msg,
-                                const pd::List &list) {}
+    virtual void receiveMessage(const std::string &/*dest*/,
+                                const std::string &/*msg*/,
+                                const pd::List &/*list*/) {}
 };
 
 } // namespace

--- a/cpp/PdTypes.hpp
+++ b/cpp/PdTypes.hpp
@@ -265,7 +265,7 @@ public:
 /// \section Util
 
     /// return number of items
-    const unsigned int len() const {return (unsigned int) objects.size();}
+    unsigned int len() const {return (unsigned int) objects.size();}
 
     /// return OSC style type string ie "fsfs"
     const std::string& types() const {return typeString;}


### PR DESCRIPTION
PdBase.hpp:
- unused parameter 'var' - Ln [823, 987]
- comparison of integer expressions of different signedness - Ln 1075

PdReceiver.hpp & PdMidiReceiver.hpp:
- 28 unused parameter warnings

PdTypes.hpp:
- type qualifiers ignored on function return type - Ln 268