### PR TITLE
Correct copyright years in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@ libpd
 
 [Pure Data](http://puredata.info) as an embeddable audio synthesis library
 
-Copyright (c) Peter Brinkmann & the libpd team 2010-2022
+Copyright (c) Peter Brinkmann & the libpd team 2010-2023
 
 Documentation
 -------------


### PR DESCRIPTION
Currently, the README incorrectly has "Copyright (c) Peter Brinkmann & the libpd team 2010-2022" when it should have "Copyright (c) Peter Brinkmann & the libpd team 2010-2023."