### PR TITLE
Includes option for AVAudioSessionCategoryOptionOverrideMutedMicrophone

### DIFF
--- a/objc/PdAudioController.h
+++ b/objc/PdAudioController.h
@@ -100,6 +100,13 @@ typedef enum PdAudioStatus {
 /// available on iSO 10+
 @property (nonatomic, assign) BOOL allowAirPlay;
 
+/// this allows audio to continue on certain devices with the privacy feature
+/// that mutes the built-in microphone and interrupts the audio.
+/// This will continue the audio session but write 0s to the input buffer
+/// applied to categories: PlayAndRecord
+/// does not apply to sessions with no audio input.
+/// available on iOS 14.5+
+@property(nonatomic, assign) BOOL allowOverrideMutedMicrophoneInterruption;
 
 #pragma mark Other Configuration Properties
 

--- a/objc/PdAudioController.m
+++ b/objc/PdAudioController.m
@@ -293,6 +293,11 @@
 			options |= AVAudioSessionCategoryOptionAllowAirPlay;
 		}
 	}
+	if (@available(iOS 14.5, *)) {
+        if (self.allowOverrideMutedMicrophoneInterruption) {
+            options |= AVAudioSessionCategoryOptionOverrideMutedMicrophoneInterruption;
+        }
+    }
 	return options;
 }
 
@@ -518,6 +523,12 @@
 	if (_allowAirPlay == allowAirPlay) {return;}
 	_allowAirPlay = allowAirPlay;
 	[self updateSessionCategoryOptions];
+}
+
+-(void)setAllowOverrideMutedMicrophoneInterruption:(BOOL)allowOverrideMutedMicrophoneInterruption {
+    if (_allowOverrideMutedMicrophoneInterruption == allowOverrideMutedMicrophoneInterruption) {return;}
+    _allowOverrideMutedMicrophoneInterruption = allowOverrideMutedMicrophoneInterruption;
+    [self updateSessionCategoryOptions];
 }
 
 #pragma mark Private


### PR DESCRIPTION
This PR updates PdAudioController.h and PdAudioController.m to include the option AVAudioSessionCategoryOptionOverrideMutedMicrophone since iOS 14.5+.  Tested on iOS 17. 

For more information see: https://developer.apple.com/documentation/avfaudio/avaudiosessioncategoryoptions/avaudiosessioncategoryoptionoverridemutedmicrophoneinterruption