### PR TITLE
Android Oboe support

### DIFF
--- a/Android.mk
+++ b/Android.mk
@@ -210,3 +210,17 @@ LOCAL_SHARED_LIBRARIES := pd
 
 include $(BUILD_SHARED_LIBRARY)
 
+
+# Build Oboe JNI binary 
+# (must be the last one because of the prefab import-module)
+
+include $(CLEAR_VARS)
+
+LOCAL_MODULE := pdnativeoboe
+LOCAL_C_INCLUDES := $(PD_C_INCLUDES) $(LOCAL_PATH)/jni
+LOCAL_SRC_FILES := jni/oboe/z_jni_oboe_shared.c jni/oboe/z_jni_oboe.cpp jni/oboe/OboeEngine.cpp
+LOCAL_SHARED_LIBRARIES := pd oboe
+LOCAL_LDLIBS := -llog
+include $(BUILD_SHARED_LIBRARY)
+
+$(call import-module, prefab/oboe)

--- a/java/org/puredata/core/PdBase.java
+++ b/java/org/puredata/core/PdBase.java
@@ -175,6 +175,27 @@ public final class PdBase {
   public native static int suggestOutputChannels();
 
   /**
+   * Select the audio input device
+   *
+   * @param deviceId an integer that identifies the device (depends on the implementation)
+   */
+  public native static void setRecordingDeviceId(int deviceId);
+
+  /**
+   * Select the audio output device
+   *
+   * @param deviceId an integer that identifies the device (depends on the implementation)
+   */
+  public native static void setPlaybackDeviceId(int deviceId);
+
+  /**
+   * Set the audio buffer size
+   *
+   * @param frames the size of the buffer in frames (e.g 2 samples for Stereo)
+   */
+  public native static void setBufferSizeInFrames(int frames);
+
+  /**
    * Closes the audio components if implementsAudio is true, otherwise no-op.
    */
   public native static void closeAudio();

--- a/java/org/puredata/core/PdBaseLoader.java
+++ b/java/org/puredata/core/PdBaseLoader.java
@@ -44,8 +44,8 @@ public abstract class PdBaseLoader {
 		        }
 		      }
 		      if (version >= 9) {
-		        System.out.println("loading pdnativeopensl for Android");
-		        System.loadLibrary("pdnativeopensl");
+		        System.out.println("loading pdnativeoboe for Android");
+		        System.loadLibrary("pdnativeoboe");
 		      } else {
 		        System.out.println("loading pdnative for Android");
 		        System.loadLibrary("pdnative");

--- a/jni/oboe/OboeEngine.cpp
+++ b/jni/oboe/OboeEngine.cpp
@@ -55,7 +55,7 @@ void OboeEngine::setBufferSizeInFrames(int frames)
 }
 
 void OboeEngine::setSampleRate(int srate) {
-    mSampleRate = srate;
+    mRequestedSampleRate = srate;
 }
 
 bool OboeEngine::setEffectOn(bool isOn) {
@@ -99,6 +99,7 @@ oboe::Result  OboeEngine::openStreams() {
     // stream first, then use properties from the playback stream
     // (e.g. sample rate) to create the recording stream. By matching the
     // properties we should get the lowest latency path
+    mSampleRate = mRequestedSampleRate;
     oboe::AudioStreamBuilder inBuilder, outBuilder;
     setupPlaybackStreamParameters(&outBuilder);
     oboe::Result result = outBuilder.openStream(mPlayStream);
@@ -164,7 +165,8 @@ oboe::AudioStreamBuilder *OboeEngine::setupPlaybackStreamParameters(
         ->setErrorCallback(this)
         ->setDeviceId(mPlaybackDeviceId)
         ->setDirection(oboe::Direction::Output)
-        ->setChannelCount(mOutputChannelCount);
+        ->setChannelCount(mOutputChannelCount)
+        ->setSampleRate(mSampleRate);
 
     return setupCommonStreamParameters(builder);
 }

--- a/jni/oboe/OboeEngine.cpp
+++ b/jni/oboe/OboeEngine.cpp
@@ -1,0 +1,281 @@
+/*
+ * Copyright (c) 2025 Antoine Rousseau
+ * (derived from 'LiveEffect' oboe sample)
+ * 
+ * For information on usage and redistribution, and for a DISCLAIMER OF ALL
+ * WARRANTIES, see the file, "LICENSE.txt," in this distribution.
+ */
+
+#include <cassert>
+#include "logging_macros.h"
+
+#include "OboeEngine.h"
+
+OboeEngine::OboeEngine() {
+}
+
+void OboeEngine::setRecordingDeviceId(int32_t deviceId) {
+    mRecordingDeviceId = deviceId;
+}
+
+void OboeEngine::setPlaybackDeviceId(int32_t deviceId) {
+    mPlaybackDeviceId = deviceId;
+}
+
+bool OboeEngine::isAAudioRecommended() {
+    return oboe::AudioStreamBuilder::isAAudioRecommended();
+}
+
+bool OboeEngine::setAudioApi(oboe::AudioApi api) {
+    if (mIsEffectOn) return false;
+    mAudioApi = api;
+    return true;
+}
+
+void OboeEngine::setChannelCounts(int numInputs, int numOutputs) {
+    mInputChannelCount = numInputs;
+    mOutputChannelCount = numOutputs;
+}
+
+void OboeEngine::getAudioParams(int &numInputs, int &numOutputs, int &sampleRate) {
+    if (!mPlayStream) return;
+    numInputs = mRecordingStream ? mRecordingStream->getChannelCount() : 0;
+    numOutputs = mPlayStream->getChannelCount();
+    sampleRate = mPlayStream->getSampleRate();
+}
+
+void OboeEngine::setAudioCallback(void (*callback)(void*), void *userData) {
+    mAudioCallback = callback;
+    mAudioCallbackUserData = userData;
+}
+
+void OboeEngine::setBufferSizeInFrames(int frames)
+{
+    if (mPlayStream) mPlayStream->setBufferSizeInFrames(frames);
+}
+
+void OboeEngine::setSampleRate(int srate) {
+    mSampleRate = srate;
+}
+
+bool OboeEngine::setEffectOn(bool isOn) {
+    bool success = true;
+    if (isOn != mIsEffectOn) {
+        if (isOn) {
+            success = openStreams() == oboe::Result::OK;
+            if (success) {
+                mIsEffectOn = isOn;
+            }
+        } else {
+            closeStreams();
+            mIsEffectOn = isOn;
+       }
+    }
+    return success;
+}
+
+void OboeEngine::closeStreams() {
+    /*
+    * Note: The order of events is important here.
+    * The playback stream must be closed before the recording stream. If the
+    * recording stream were to be closed first the playback stream's
+    * callback may attempt to read from the recording stream
+    * which would cause the app to crash since the recording stream would be
+    * null.
+    */
+    if (mDuplexStream) {
+        mDuplexStream->stop();
+        closeStream(mPlayStream);
+        closeStream(mRecordingStream);
+        mDuplexStream.reset();
+    } else {
+        closeStream(mPlayStream);
+        mSimplexStream.reset();
+    }
+}
+
+oboe::Result  OboeEngine::openStreams() {
+    // Note: The order of stream creation is important. We create the playback
+    // stream first, then use properties from the playback stream
+    // (e.g. sample rate) to create the recording stream. By matching the
+    // properties we should get the lowest latency path
+    oboe::AudioStreamBuilder inBuilder, outBuilder;
+    setupPlaybackStreamParameters(&outBuilder);
+    oboe::Result result = outBuilder.openStream(mPlayStream);
+    if (result != oboe::Result::OK) {
+        LOGE("Failed to open output stream. Error %s", oboe::convertToText(result));
+        mSampleRate = oboe::kUnspecified;
+        return result;
+    } else {
+        // The input stream needs to run at the same sample rate as the output.
+        mSampleRate = mPlayStream->getSampleRate();
+    }
+    warnIfNotLowLatency(mPlayStream);
+
+    if (mInputChannelCount > 0) {
+        setupRecordingStreamParameters(&inBuilder, mSampleRate);
+        result = inBuilder.openStream(mRecordingStream);
+        if (result != oboe::Result::OK) {
+            LOGE("Failed to open input stream. Error %s", oboe::convertToText(result));
+        } else {
+            warnIfNotLowLatency(mRecordingStream);
+        }
+    }
+
+    if (mRecordingStream) {
+        mDuplexStream = std::make_unique<PdStreamDuplex>();
+        mDuplexStream->setSharedInputStream(mRecordingStream);
+        mDuplexStream->setSharedOutputStream(mPlayStream);
+        mDuplexStream->start();
+    } else {
+        mSimplexStream = std::make_unique<PdStreamSimplex>();
+        mPlayStream->start();
+    }
+    return oboe::Result::OK;
+}
+
+/**
+ * Sets the stream parameters which are specific to recording,
+ * including the sample rate which is determined from the
+ * playback stream.
+ *
+ * @param builder The recording stream builder
+ * @param sampleRate The desired sample rate of the recording stream
+ */
+oboe::AudioStreamBuilder *OboeEngine::setupRecordingStreamParameters(
+    oboe::AudioStreamBuilder *builder, int32_t sampleRate) {
+    // This sample uses blocking read() because we don't specify a callback
+    builder->setDeviceId(mRecordingDeviceId)
+        ->setDirection(oboe::Direction::Input)
+        ->setSampleRate(sampleRate)
+        ->setChannelCount(mInputChannelCount);
+    return setupCommonStreamParameters(builder);
+}
+
+/**
+ * Sets the stream parameters which are specific to playback, including device
+ * id and the dataCallback function, which must be set for low latency
+ * playback.
+ * @param builder The playback stream builder
+ */
+oboe::AudioStreamBuilder *OboeEngine::setupPlaybackStreamParameters(
+    oboe::AudioStreamBuilder *builder) {
+    builder->setDataCallback(this)
+        ->setErrorCallback(this)
+        ->setDeviceId(mPlaybackDeviceId)
+        ->setDirection(oboe::Direction::Output)
+        ->setChannelCount(mOutputChannelCount);
+
+    return setupCommonStreamParameters(builder);
+}
+
+/**
+ * Set the stream parameters which are common to both recording and playback
+ * streams.
+ * @param builder The playback or recording stream builder
+ */
+oboe::AudioStreamBuilder *OboeEngine::setupCommonStreamParameters(
+    oboe::AudioStreamBuilder *builder) {
+    // We request EXCLUSIVE mode since this will give us the lowest possible
+    // latency.
+    // If EXCLUSIVE mode isn't available the builder will fall back to SHARED
+    // mode.
+    builder->setAudioApi(mAudioApi)
+        ->setFormat(mFormat)
+        ->setFormatConversionAllowed(true)
+        ->setSharingMode(oboe::SharingMode::Exclusive)
+        ->setPerformanceMode(oboe::PerformanceMode::LowLatency);
+    return builder;
+}
+
+/**
+ * Close the stream. AudioStream::close() is a blocking call so
+ * the application does not need to add synchronization between
+ * onAudioReady() function and the thread calling close().
+ * [the closing thread is the UI thread in this sample].
+ * @param stream the stream to close
+ */
+void OboeEngine::closeStream(std::shared_ptr<oboe::AudioStream> &stream) {
+    if (stream) {
+        oboe::Result result = stream->stop();
+        if (result != oboe::Result::OK) {
+            LOGW("Error stopping stream: %s", oboe::convertToText(result));
+        }
+        result = stream->close();
+        if (result != oboe::Result::OK) {
+            LOGE("Error closing stream: %s", oboe::convertToText(result));
+        } else {
+            LOGW("Successfully closed streams");
+        }
+        stream.reset();
+    }
+}
+
+/**
+ * Warn in logcat if non-low latency stream is created
+ * @param stream: newly created stream
+ *
+ */
+void OboeEngine::warnIfNotLowLatency(std::shared_ptr<oboe::AudioStream> &stream) {
+    if (stream->getPerformanceMode() != oboe::PerformanceMode::LowLatency) {
+        LOGW(
+            "Stream is NOT low latency."
+            "Check your requested format, sample rate and channel count");
+    }
+}
+
+/**
+ * Handles playback stream's audio request. In this sample, we simply block-read
+ * from the record stream for the required samples.
+ *
+ * @param oboeStream: the playback stream that requesting additional samples
+ * @param audioData:  the buffer to load audio samples for playback stream
+ * @param numFrames:  number of frames to load to audioData buffer
+ * @return: DataCallbackResult::Continue.
+ */
+oboe::DataCallbackResult OboeEngine::onAudioReady(
+    oboe::AudioStream *oboeStream, void *audioData, int32_t numFrames) {
+    if (mAudioCallback) {
+        mAudioCallback(mAudioCallbackUserData);
+    }
+    if (mDuplexStream) {
+        return mDuplexStream->onAudioReady(oboeStream, audioData, numFrames);
+    } else if (mSimplexStream) {
+        return mSimplexStream->onAudioReady(oboeStream, audioData, numFrames);
+    }
+    return oboe::DataCallbackResult::Stop;
+}
+
+/**
+ * Oboe notifies the application for "about to close the stream".
+ *
+ * @param oboeStream: the stream to close
+ * @param error: oboe's reason for closing the stream
+ */
+void OboeEngine::onErrorBeforeClose(oboe::AudioStream *oboeStream,
+                                          oboe::Result error) {
+    LOGE("%s stream Error before close: %s",
+         oboe::convertToText(oboeStream->getDirection()),
+         oboe::convertToText(error));
+}
+
+/**
+ * Oboe notifies application that "the stream is closed"
+ *
+ * @param oboeStream
+ * @param error
+ */
+void OboeEngine::onErrorAfterClose(oboe::AudioStream *oboeStream,
+                                         oboe::Result error) {
+    LOGE("%s stream Error after close: %s",
+         oboe::convertToText(oboeStream->getDirection()),
+         oboe::convertToText(error));
+
+    closeStreams();
+
+    // Restart the stream if the error is a disconnect.
+    if (error == oboe::Result::ErrorDisconnected) {
+        LOGI("Restarting AudioStream");
+        openStreams();
+    }
+}

--- a/jni/oboe/OboeEngine.h
+++ b/jni/oboe/OboeEngine.h
@@ -1,0 +1,85 @@
+/*
+ * Copyright (c) 2025 Antoine Rousseau
+ * (derived from 'LiveEffect' oboe sample)
+ * 
+ * For information on usage and redistribution, and for a DISCLAIMER OF ALL
+ * WARRANTIES, see the file, "LICENSE.txt," in this distribution.
+ */
+
+#ifndef OBOE_ENGINE_H
+#define OBOE_ENGINE_H
+
+#include <jni.h>
+#include <oboe/Oboe.h>
+#include <string>
+#include <thread>
+#include "PdStreams.h"
+
+class OboeEngine : public oboe::AudioStreamCallback {
+public:
+    OboeEngine();
+
+    void setRecordingDeviceId(int32_t deviceId);
+    void setPlaybackDeviceId(int32_t deviceId);
+    bool setAudioApi(oboe::AudioApi);
+    bool isAAudioRecommended(void);
+    void setChannelCounts(int numInputs, int numOutputs);
+    void getAudioParams(int &numInputs, int &numOutputs, int &sampleRate);
+    void setBufferSizeInFrames(int frames);
+    void setSampleRate(int srate);
+
+    /* optional user audio callback */
+    void setAudioCallback(void (*callback)(void*), void *userData = nullptr);
+
+    /**
+     * @param isOn
+     * @return true if it succeeds
+     */
+    bool setEffectOn(bool isOn);
+
+    /*
+     * oboe::AudioStreamDataCallback interface implementation
+     */
+    oboe::DataCallbackResult onAudioReady(oboe::AudioStream *oboeStream,
+                                          void *audioData, int32_t numFrames) override;
+
+    /*
+     * oboe::AudioStreamErrorCallback interface implementation
+     */
+    void onErrorBeforeClose(oboe::AudioStream *oboeStream, oboe::Result error) override;
+    void onErrorAfterClose(oboe::AudioStream *oboeStream, oboe::Result error) override;
+
+private:
+    bool mIsEffectOn = false;
+    int32_t mRecordingDeviceId = oboe::kUnspecified;
+    int32_t mPlaybackDeviceId = oboe::kUnspecified;
+    const oboe::AudioFormat mFormat = oboe::AudioFormat::Float; // for easier processing
+    oboe::AudioApi mAudioApi = oboe::AudioApi::AAudio;
+    int32_t mSampleRate = oboe::kUnspecified;
+    int32_t mInputChannelCount = oboe::ChannelCount::Stereo;
+    int32_t mOutputChannelCount = oboe::ChannelCount::Stereo;
+
+    std::unique_ptr<PdStreamDuplex> mDuplexStream;
+    std::unique_ptr<PdStreamSimplex> mSimplexStream;
+    std::shared_ptr<oboe::AudioStream> mRecordingStream;
+    std::shared_ptr<oboe::AudioStream> mPlayStream;
+
+    void (*mAudioCallback)(void *data) = nullptr;
+    void *mAudioCallbackUserData = nullptr;
+
+    oboe::Result openStreams();
+
+    void closeStreams();
+
+    void closeStream(std::shared_ptr<oboe::AudioStream> &stream);
+
+    oboe::AudioStreamBuilder *setupCommonStreamParameters(
+        oboe::AudioStreamBuilder *builder);
+    oboe::AudioStreamBuilder *setupRecordingStreamParameters(
+        oboe::AudioStreamBuilder *builder, int32_t sampleRate);
+    oboe::AudioStreamBuilder *setupPlaybackStreamParameters(
+        oboe::AudioStreamBuilder *builder);
+    void warnIfNotLowLatency(std::shared_ptr<oboe::AudioStream> &stream);
+};
+
+#endif  // OBOE_ENGINE_H

--- a/jni/oboe/OboeEngine.h
+++ b/jni/oboe/OboeEngine.h
@@ -56,6 +56,7 @@ private:
     const oboe::AudioFormat mFormat = oboe::AudioFormat::Float; // for easier processing
     oboe::AudioApi mAudioApi = oboe::AudioApi::AAudio;
     int32_t mSampleRate = oboe::kUnspecified;
+    int32_t mRequestedSampleRate = oboe::kUnspecified;
     int32_t mInputChannelCount = oboe::ChannelCount::Stereo;
     int32_t mOutputChannelCount = oboe::ChannelCount::Stereo;
 

--- a/jni/oboe/PdStreams.h
+++ b/jni/oboe/PdStreams.h
@@ -1,0 +1,175 @@
+/*
+ * Copyright (c) 2025 Antoine Rousseau
+ *
+ * For information on usage and redistribution, and for a DISCLAIMER OF ALL
+ * WARRANTIES, see the file, "LICENSE.txt," in this distribution.
+ */
+
+#pragma once
+
+#include "z_libpd.h"
+
+extern "C" {
+    pthread_mutex_t *jni_oboe_get_libpd_mutex();
+}
+
+class PdStreamDuplex : public oboe::FullDuplexStream {
+private:
+    static const int MAX_NFRAMES = 8192;
+    static const int MAX_IN_CHANS = 8;
+    static const int MAX_OUT_CHANS = 8;
+    static const int PD_BLOCKSIZE = 64;
+    pthread_mutex_t &mutex = *jni_oboe_get_libpd_mutex();
+
+    class InputBuffer {
+    private:
+        static const int BUFSIZE = MAX_NFRAMES * MAX_IN_CHANS;
+        float ringbuffer[BUFSIZE];
+        float blockbuffer[PD_BLOCKSIZE * MAX_IN_CHANS];
+        int queue = 0;
+        int tail = 0;
+    public:
+        bool is_empty() {
+            return queue == tail;
+        }
+        bool is_full() {
+            return ((tail + 1) % BUFSIZE) == queue;
+        }
+        void push(const float *samples, int nsamples) {
+            for(int c = 0; c < nsamples; c++) {
+                if(is_full()) break;
+                ringbuffer[tail++] = samples[c];
+                if(tail == BUFSIZE)
+                    tail = 0;
+            }
+        }
+        float *pop_block(int nchannels) {
+            int nsamples = PD_BLOCKSIZE * nchannels;
+            for(int i = 0 ; i < nsamples; i++) {
+                float s = 0.0;
+                if(!is_empty()) {
+                    s = ringbuffer[queue++];
+                    if(queue == BUFSIZE)
+                        queue = 0;
+                }
+                blockbuffer[i] = s;
+            }
+            return blockbuffer;
+        }
+    } inputBuffer;
+
+    class OutputBuffer {
+    private:
+        float buffer[PD_BLOCKSIZE * MAX_OUT_CHANS];
+        int len = 0;
+        int index = 0;
+    public:
+        bool is_empty() {
+            return index == len;
+        }
+        float *init(int nsamples) {
+            len = nsamples;
+            index = 0;
+            return buffer;
+        }
+        float pop() {
+            return buffer[index++];
+        }
+    } outputBuffer;
+
+public:
+    virtual oboe::DataCallbackResult onBothStreamsReady(
+            const void *inputData,
+            int   numInputFrames,
+            void *outputData,
+            int   numOutputFrames) {
+
+        // This code assumes the data format for both streams is Float.
+        const float *inputFloats = static_cast<const float *>(inputData);
+        float *outputFloats = static_cast<float *>(outputData);
+
+        int32_t inChannels = getInputStream()->getChannelCount();
+        int32_t outChannels = getOutputStream()->getChannelCount();
+        int32_t numInputSamples = numInputFrames * inChannels;
+        int32_t numOutputSamples = numOutputFrames * outChannels;
+
+        // Store input samples in inputBuffer ring buffer
+        if(numInputSamples < MAX_NFRAMES) // ignore too big buffers
+            inputBuffer.push(inputFloats, numInputSamples);
+
+        int processedSamples = 0;
+        while(processedSamples < numOutputSamples) {
+            // If outputBuffer is empty, get a new one from Pd in exchange for a block from inputBuffer.
+            // When inputBuffer doesn't have enough data, it fills the block with zeroes.
+            if(outputBuffer.is_empty()) {
+                pthread_mutex_lock(&mutex);
+                libpd_process_float(1, 
+                    inputBuffer.pop_block(inChannels),
+                    outputBuffer.init(PD_BLOCKSIZE * outChannels)
+                );
+                pthread_mutex_unlock(&mutex);
+            }
+            // Send next outputBuffer sample to audio output
+            outputFloats[processedSamples++] = outputBuffer.pop();
+        }
+
+        return oboe::DataCallbackResult::Continue;
+    }
+};
+
+class PdStreamSimplex {
+private:
+    static const int MAX_NFRAMES = 8192;
+    static const int MAX_OUT_CHANS = 8;
+    static const int PD_BLOCKSIZE = 64;
+    pthread_mutex_t &mutex = *jni_oboe_get_libpd_mutex();
+
+    class OutputBuffer {
+    private:
+        float buffer[PD_BLOCKSIZE * MAX_OUT_CHANS];
+        int len = 0;
+        int index = 0;
+    public:
+        bool is_empty() {
+            return index == len;
+        }
+        float *init(int nsamples) {
+            len = nsamples;
+            index = 0;
+            return buffer;
+        }
+        float pop() {
+            return buffer[index++];
+        }
+    } outputBuffer;
+
+public:
+    oboe::DataCallbackResult onAudioReady(
+            oboe::AudioStream *oboeStream,
+            void *outputData,
+            int   numOutputFrames) {
+
+        float *outputFloats = static_cast<float *>(outputData);
+
+        int32_t outChannels = oboeStream->getChannelCount();
+        int32_t numOutputSamples = numOutputFrames * outChannels;
+        int processedSamples = 0;
+        while(processedSamples < numOutputSamples) {
+            // If outputBuffer is empty, get a new one from Pd.
+            if(outputBuffer.is_empty()) {
+                float dummy;
+                pthread_mutex_lock(&mutex);
+                libpd_process_float(1, 
+                    &dummy,
+                    outputBuffer.init(PD_BLOCKSIZE * outChannels)
+                );
+                pthread_mutex_unlock(&mutex);
+            }
+            // Send next outputBuffer sample to audio output
+            outputFloats[processedSamples++] = outputBuffer.pop();
+        }
+
+        return oboe::DataCallbackResult::Continue;
+    }
+};
+

--- a/jni/oboe/logging_macros.h
+++ b/jni/oboe/logging_macros.h
@@ -1,0 +1,46 @@
+/*
+ * Copyright (C) 2017 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+#ifndef __SAMPLE_ANDROID_DEBUG_H__
+#define __SAMPLE_ANDROID_DEBUG_H__
+#include <android/log.h>
+
+#if 1
+#ifndef MODULE_NAME
+#define MODULE_NAME  "AUDIO-APP"
+#endif
+
+#define LOGV(...) __android_log_print(ANDROID_LOG_VERBOSE, MODULE_NAME, __VA_ARGS__)
+#define LOGD(...) __android_log_print(ANDROID_LOG_DEBUG, MODULE_NAME, __VA_ARGS__)
+#define LOGI(...) __android_log_print(ANDROID_LOG_INFO, MODULE_NAME, __VA_ARGS__)
+#define LOGW(...) __android_log_print(ANDROID_LOG_WARN,MODULE_NAME, __VA_ARGS__)
+#define LOGE(...) __android_log_print(ANDROID_LOG_ERROR,MODULE_NAME, __VA_ARGS__)
+#define LOGF(...) __android_log_print(ANDROID_LOG_FATAL,MODULE_NAME, __VA_ARGS__)
+
+#define ASSERT(cond, ...) if (!(cond)) {__android_log_assert(#cond, MODULE_NAME, __VA_ARGS__);}
+#else
+
+#define LOGV(...)
+#define LOGD(...)
+#define LOGI(...)
+#define LOGW(...)
+#define LOGE(...)
+#define LOGF(...)
+#define ASSERT(cond, ...)
+
+#endif
+
+#endif // __SAMPLE_ANDROID_DEBUG_H__

--- a/jni/oboe/z_jni_oboe.cpp
+++ b/jni/oboe/z_jni_oboe.cpp
@@ -52,7 +52,7 @@ jobject options) {
         engine = new OboeEngine();
     }
     if (engine != nullptr) {
-        LOGE("requested sample rate %d", sRate);
+        LOGV("requested sample rate %d", sRate);
         engine->setSampleRate(sRate < 0 ? oboe::kUnspecified : sRate);
         engine->setAudioApi(engine->isAAudioRecommended() ? oboe::AudioApi::AAudio : oboe::AudioApi::OpenSLES);
         engine->setChannelCounts(
@@ -77,7 +77,7 @@ JNIEXPORT jint JNICALL Java_org_puredata_core_PdBase_startAudio
         int inChans, outChans, sRate;
         engine->getAudioParams(inChans, outChans, sRate);
         libpd_init_audio(inChans, outChans, sRate);
-        LOGE("final sample rate %d", sRate);
+        LOGV("final sample rate %d", sRate);
     }
     return isRunning ? 0 : -1;
 }

--- a/jni/oboe/z_jni_oboe.cpp
+++ b/jni/oboe/z_jni_oboe.cpp
@@ -1,0 +1,154 @@
+/*
+ * Copyright (c) 2025 Antoine Rousseau
+ *
+ * For information on usage and redistribution, and for a DISCLAIMER OF ALL
+ * WARRANTIES, see the file, "LICENSE.txt," in this distribution.
+ */
+
+#include "logging_macros.h"
+#include "z_jni_oboe.h"
+
+static OboeEngine *engine = nullptr;
+static bool isRunning = false;
+
+pthread_mutex_t &mutex = *jni_oboe_get_libpd_mutex();
+
+OboeEngine *jni_oboe_get_engine() {
+    return engine;
+}
+
+extern "C" {
+
+JNIEXPORT jstring JNICALL Java_org_puredata_core_PdBase_audioImplementation
+(JNIEnv *env , jclass cls) {
+    return env->NewStringUTF("Oboe");
+}
+
+JNIEXPORT jboolean JNICALL Java_org_puredata_core_PdBase_implementsAudio
+(JNIEnv *env, jclass cls) {
+    return JNI_TRUE;
+}
+
+JNIEXPORT void JNICALL Java_org_puredata_core_PdBase_closeAudio
+(JNIEnv *env, jclass cls) {
+    if (engine) {
+        engine->setEffectOn(false);
+        isRunning = false;
+        delete engine;
+        engine = nullptr;
+    }
+}
+
+JNIEXPORT jint JNICALL Java_org_puredata_core_PdBase_openAudio
+(JNIEnv *env, jclass cls, jint inChans, jint outChans, jint sRate,
+jobject options) {
+    Java_org_puredata_core_PdBase_closeAudio(env, cls);
+    pthread_mutex_lock(&mutex);
+    // Pd audio parameters will be updated later, in startAudio
+    jint err = libpd_init_audio(2, 2, 48000);
+    pthread_mutex_unlock(&mutex);
+    if (err) return err;
+    if (engine == nullptr) {
+        engine = new OboeEngine();
+    }
+    if (engine != nullptr) {
+        LOGE("requested sample rate %d", sRate);
+        engine->setSampleRate(sRate < 0 ? oboe::kUnspecified : sRate);
+        engine->setAudioApi(engine->isAAudioRecommended() ? oboe::AudioApi::AAudio : oboe::AudioApi::OpenSLES);
+        engine->setChannelCounts(
+            inChans < 0 ? oboe::kUnspecified : inChans,
+            outChans < 0 ? oboe::kUnspecified : outChans
+        );
+    }
+    return (engine == nullptr) ? -1 : 0;
+}
+
+JNIEXPORT jint JNICALL Java_org_puredata_core_PdBase_startAudio
+(JNIEnv *env, jclass cls) {
+    if (engine == nullptr) {
+        LOGE(
+            "Engine is null, you must call createEngine before calling startAudio "
+            "method");
+        return -1;
+    }
+    isRunning = engine->setEffectOn(true);
+    // update Pd audio parameters for the actual devices
+    if (isRunning) {
+        int inChans, outChans, sRate;
+        engine->getAudioParams(inChans, outChans, sRate);
+        libpd_init_audio(inChans, outChans, sRate);
+        LOGE("final sample rate %d", sRate);
+    }
+    return isRunning ? 0 : -1;
+}
+
+JNIEXPORT jint JNICALL Java_org_puredata_core_PdBase_pauseAudio
+(JNIEnv *env, jclass cls) {
+    if (engine == nullptr) {
+        LOGE(
+            "Engine is null, you must call createEngine before calling pauseAudio "
+            "method");
+        return -1;
+    }
+    isRunning = false;
+    engine->setEffectOn(false);
+    return 0;
+}
+
+JNIEXPORT jboolean JNICALL Java_org_puredata_core_PdBase_isRunning
+(JNIEnv *env, jclass cls) {
+  return engine && isRunning;
+}
+
+JNIEXPORT jint JNICALL Java_org_puredata_core_PdBase_suggestSampleRate
+(JNIEnv *env, jclass cls) {
+  return -1;
+}
+
+JNIEXPORT jint JNICALL Java_org_puredata_core_PdBase_suggestInputChannels
+(JNIEnv *env, jclass cls) {
+  return -1;
+}
+
+JNIEXPORT jint JNICALL Java_org_puredata_core_PdBase_suggestOutputChannels
+(JNIEnv *env, jclass cls) {
+  return -1;
+}
+
+
+JNIEXPORT void JNICALL Java_org_puredata_core_PdBase_setRecordingDeviceId
+(JNIEnv *env, jclass, jint deviceId) {
+    if (engine == nullptr) {
+        LOGE(
+            "Engine is null, you must call createEngine before calling setRecordingDeviceId "
+            "method");
+        return;
+    }
+
+    engine->setRecordingDeviceId(deviceId < 0 ? oboe::kUnspecified : deviceId);
+}
+
+JNIEXPORT void JNICALL Java_org_puredata_core_PdBase_setPlaybackDeviceId
+(JNIEnv *env, jclass, jint deviceId) {
+    if (engine == nullptr) {
+        LOGE(
+            "Engine is null, you must call createEngine before calling setPlaybackDeviceId "
+            "method");
+        return;
+    }
+    engine->setPlaybackDeviceId(deviceId < 0 ? oboe::kUnspecified : deviceId);
+}
+
+JNIEXPORT void JNICALL Java_org_puredata_core_PdBase_setBufferSizeInFrames
+(JNIEnv *env, jclass, jint frames) {
+    if (engine == nullptr) {
+        LOGE(
+            "Engine is null, you must call createEngine before calling setBufferSizeInFrames "
+            "method");
+        return;
+    }
+    engine->setBufferSizeInFrames(frames);
+}
+
+} // extern "C"
+

--- a/jni/oboe/z_jni_oboe.h
+++ b/jni/oboe/z_jni_oboe.h
@@ -1,0 +1,13 @@
+/*
+ * Copyright (c) 2025 Antoine Rousseau
+ *
+ * For information on usage and redistribution, and for a DISCLAIMER OF ALL
+ * WARRANTIES, see the file, "LICENSE.txt," in this distribution.
+ */
+
+#pragma once
+
+#include "OboeEngine.h"
+
+OboeEngine *jni_oboe_get_engine();
+

--- a/jni/oboe/z_jni_oboe_shared.c
+++ b/jni/oboe/z_jni_oboe_shared.c
@@ -1,0 +1,7 @@
+
+#include "z_jni_shared.c"
+
+// export mutex to C++
+pthread_mutex_t *jni_oboe_get_libpd_mutex() {
+    return &mutex;
+}

--- a/jni/z_jni.h
+++ b/jni/z_jni.h
@@ -97,6 +97,30 @@ JNIEXPORT jint JNICALL Java_org_puredata_core_PdBase_suggestOutputChannels
 
 /*
  * Class:     org_puredata_core_PdBase
+ * Method:    setRecordingDeviceId
+ * Signature: (I)V
+ */
+JNIEXPORT void JNICALL Java_org_puredata_core_PdBase_setRecordingDeviceId
+  (JNIEnv *, jclass, jint);
+
+/*
+ * Class:     org_puredata_core_PdBase
+ * Method:    setPlaybackDeviceId
+ * Signature: (I)V
+ */
+JNIEXPORT void JNICALL Java_org_puredata_core_PdBase_setPlaybackDeviceId
+  (JNIEnv *, jclass, jint);
+
+/*
+ * Class:     org_puredata_core_PdBase
+ * Method:    setBufferSizeInFrames
+ * Signature: (I)V
+ */
+JNIEXPORT void JNICALL Java_org_puredata_core_PdBase_setBufferSizeInFrames
+  (JNIEnv *, jclass, jint);
+
+/*
+ * Class:     org_puredata_core_PdBase
  * Method:    closeAudio
  * Signature: ()V
  */

--- a/jni/z_jni_opensl.c
+++ b/jni/z_jni_opensl.c
@@ -85,3 +85,13 @@ JNIEXPORT jint JNICALL Java_org_puredata_core_PdBase_suggestOutputChannels
 (JNIEnv *env, jclass cls) {
   return -1;
 }
+
+JNIEXPORT void JNICALL Java_org_puredata_core_PdBase_setRecordingDeviceId
+  (JNIEnv *env, jclass cls, jint deviceId) {}
+
+JNIEXPORT void JNICALL Java_org_puredata_core_PdBase_setPlaybackDeviceId
+  (JNIEnv *env, jclass cls, jint deviceId) {}
+
+JNIEXPORT void JNICALL Java_org_puredata_core_PdBase_setBufferSizeInFrames
+  (JNIEnv *env, jclass cls, jint frames) {}
+

--- a/jni/z_jni_pa.c
+++ b/jni/z_jni_pa.c
@@ -92,3 +92,13 @@ JNIEXPORT jboolean JNICALL Java_org_puredata_core_PdBase_isRunning(JNIEnv *env,
                                                                    jclass cls) {
   return pa_stream && Pa_IsStreamActive(pa_stream);
 }
+
+JNIEXPORT void JNICALL Java_org_puredata_core_PdBase_setRecordingDeviceId
+  (JNIEnv *env, jclass cls, jint deviceId) {}
+
+JNIEXPORT void JNICALL Java_org_puredata_core_PdBase_setPlaybackDeviceId
+  (JNIEnv *env, jclass cls, jint deviceId) {}
+
+JNIEXPORT void JNICALL Java_org_puredata_core_PdBase_setBufferSizeInFrames
+  (JNIEnv *env, jclass cls, jint frames) {}
+

--- a/jni/z_jni_plain.c
+++ b/jni/z_jni_plain.c
@@ -61,3 +61,12 @@ JNIEXPORT jint JNICALL Java_org_puredata_core_PdBase_suggestOutputChannels
   return -1;
 }
 
+JNIEXPORT void JNICALL Java_org_puredata_core_PdBase_setRecordingDeviceId
+  (JNIEnv *env, jclass cls, jint deviceId) {}
+
+JNIEXPORT void JNICALL Java_org_puredata_core_PdBase_setPlaybackDeviceId
+  (JNIEnv *env, jclass cls, jint deviceId) {}
+
+JNIEXPORT void JNICALL Java_org_puredata_core_PdBase_setBufferSizeInFrames
+  (JNIEnv *env, jclass cls, jint frames) {}
+


### PR DESCRIPTION
This implements the native interface for the Oboe audio driver library.

It takes care of the buffer size conversion between Pd and Oboe, separately for input and output (since Oboe can provide less input samples than output ones, mainly on start).

It also extends the PdBase jni a bit, to allow selecting input and output audio devices (which Oboe offers), and setting the audio buffer size.

The new `pdnativeoboe.so` is now loaded by PdBase loader when on Android, replacing the previous `pdnativeopensl.so`.

Closes #284.