### PR TITLE
Android Oboe support (2)

### DIFF
--- a/Android.mk
+++ b/Android.mk
@@ -210,3 +210,17 @@ LOCAL_SHARED_LIBRARIES := pd
 
 include $(BUILD_SHARED_LIBRARY)
 
+
+# Build Oboe JNI binary
+# (must be the last one because of the prefab import-module)
+
+include $(CLEAR_VARS)
+
+LOCAL_MODULE := pdnativeoboe
+LOCAL_C_INCLUDES := $(PD_C_INCLUDES) $(LOCAL_PATH)/jni
+LOCAL_SRC_FILES := jni/oboe/z_jni_oboe_shared.c jni/oboe/z_jni_oboe.cpp jni/oboe/OboeEngine.cpp
+LOCAL_SHARED_LIBRARIES := pd oboe
+LOCAL_LDLIBS := -llog
+include $(BUILD_SHARED_LIBRARY)
+
+$(call import-module, prefab/oboe)

--- a/Makefile
+++ b/Makefile
@@ -246,6 +246,8 @@ $(JNIH_FILE): $(JAVA_BASE)
 	javac -classpath java $^ -h jni
 	mv jni/org_puredata_core_PdBase.h jni/z_jni.h
 
+${JNI_SOUND:.c=.o}: jni/z_jni_shared.c
+
 $(PDJAVA_NATIVE): ${PD_FILES:.c=.o} ${LIBPD_UTILS:.c=.o} ${EXTRA_FILES:.c=.o} ${JNI_FILE:.c=.o}
 	mkdir -p $(PDJAVA_DIR)
 	$(CC) -o $(PDJAVA_NATIVE) $^ -lm -lpthread $(JAVA_LDFLAGS)

--- a/java/org/puredata/core/PdBase.java
+++ b/java/org/puredata/core/PdBase.java
@@ -130,10 +130,10 @@ public final class PdBase {
    * @param inputChannels Number of input channels
    * @param outputChannels Number of output channels
    * @param sampleRate Audio sample rate
-   * @param options Audio backend options, specific to the audio implementation.
+   * @param options Audio backend options, specific to the audio implementation:
    * <p>
    * <table>
-   *   <caption>Oboe options</caption>
+   *   <caption>Oboe initialization options</caption>
    *   <thead>
    *     <tr>
    *       <th scope="col">Key</th>
@@ -160,6 +160,38 @@ public final class PdBase {
    */
   public native static int openAudio(int inputChannels, int outputChannels, int sampleRate,
       Map<String, String> options);
+
+  /**
+   * Get the value of the audio runtime property indicated by the string 'key'. The key/value pairs are
+   * specific to the current audio implementation.
+   * <p>
+   * <table>
+   *   <caption>Oboe runtime properties</caption>
+   *   <thead>
+   *     <tr>
+   *       <th scope="col">Key</th>
+   *       <th scope="col">Value</th>
+   *     </tr>
+   *   </thead>
+   *   <tbody>
+   *     <tr>
+   *       <td>"latencyMillis"</td>
+   *       <td>the calculated latency in milliseconds</td>
+   *     </tr>
+   *     <tr>
+   *       <td>"xRuns"</td>
+   *       <td>number of buffer overruns or underruns since audio started</td>
+   *     </tr>
+   *     <tr>
+   *       <td>"sampleRate"</td>
+   *       <td>final sampling rate</td>
+   *     </tr>
+   *   </tbody>
+   * </table>
+   *
+   * @return a string containing the value of the 'key' property, "unknown" if no such property.
+   */
+  public native static String audioRuntimeInfo(String key);
 
   /**
    * Indicates whether the underlying binary implements audio, e.g., with Oboe or PortAudio or

--- a/java/org/puredata/core/PdBase.java
+++ b/java/org/puredata/core/PdBase.java
@@ -127,17 +127,42 @@ public final class PdBase {
   /**
    * Sets up Pd audio; must be called before rendering audio with process or startAudio.
    *
-   * @param inputChannels Number of input channles
+   * @param inputChannels Number of input channels
    * @param outputChannels Number of output channels
    * @param sampleRate Audio sample rate
-   * @param options Audio backend options, reserved for future use.
+   * @param options Audio backend options, specific to the audio implementation.
+   * <p>
+   * <table>
+   *   <caption>Oboe options</caption>
+   *   <thead>
+   *     <tr>
+   *       <th scope="col">Key</th>
+   *       <th scope="col">Value</th>
+   *     </tr>
+   *   </thead>
+   *   <tbody>
+   *     <tr>
+   *       <td>"inputDeviceId"</td>
+   *       <td>id of the audio input device</td>
+   *     </tr>
+   *     <tr>
+   *       <td>"outputDeviceId"</td>
+   *       <td>id of the audio output device</td>
+   *     </tr>
+   *     <tr>
+   *       <td>"bufferSizeInFrames"</td>
+   *       <td>size of the buffer in frames (e.g 2 samples for Stereo)</td>
+   *     </tr>
+   *   </tbody>
+   * </table>
    * @return error code, 0 on success
+   *
    */
   public native static int openAudio(int inputChannels, int outputChannels, int sampleRate,
       Map<String, String> options);
 
   /**
-   * Indicates whether the underlying binary implements audio, e.g., with OpenSL or PortAudio or
+   * Indicates whether the underlying binary implements audio, e.g., with Oboe or PortAudio or
    * JACK.
    *
    * @return true there is an audio implementation
@@ -145,7 +170,7 @@ public final class PdBase {
   public native static boolean implementsAudio();
 
   /**
-   * Indicates how the underlying binary implements audio, e.g., with OpenSL or PortAudio or JACK.
+   * Indicates how the underlying binary implements audio, e.g., with Oboe or PortAudio or JACK.
    *
    * @return audio backend name or null if there is no audio implementation
    */

--- a/java/org/puredata/core/PdBaseLoader.java
+++ b/java/org/puredata/core/PdBaseLoader.java
@@ -44,8 +44,8 @@ public abstract class PdBaseLoader {
 		        }
 		      }
 		      if (version >= 9) {
-		        System.out.println("loading pdnativeopensl for Android");
-		        System.loadLibrary("pdnativeopensl");
+		        System.out.println("loading pdnativeoboe for Android");
+		        System.loadLibrary("pdnativeoboe");
 		      } else {
 		        System.out.println("loading pdnative for Android");
 		        System.loadLibrary("pdnative");

--- a/jni/oboe/OboeEngine.cpp
+++ b/jni/oboe/OboeEngine.cpp
@@ -1,0 +1,291 @@
+/*
+ * Copyright (c) 2025 Antoine Rousseau
+ * (derived from 'LiveEffect' oboe sample)
+ *
+ * For information on usage and redistribution, and for a DISCLAIMER OF ALL
+ * WARRANTIES, see the file, "LICENSE.txt," in this distribution.
+ */
+
+#include <cassert>
+#include "logging_macros.h"
+
+#include "OboeEngine.h"
+
+OboeEngine::OboeEngine() {
+}
+
+void OboeEngine::setRecordingDeviceId(int32_t deviceId) {
+    mRecordingDeviceId = deviceId;
+}
+
+void OboeEngine::setPlaybackDeviceId(int32_t deviceId) {
+    mPlaybackDeviceId = deviceId;
+}
+
+bool OboeEngine::isAAudioRecommended() {
+    return oboe::AudioStreamBuilder::isAAudioRecommended();
+}
+
+bool OboeEngine::setAudioApi(oboe::AudioApi api) {
+    if (mIsEffectOn) return false;
+    mAudioApi = api;
+    return true;
+}
+
+void OboeEngine::setChannelCounts(int numInputs, int numOutputs) {
+    mInputChannelCount = numInputs;
+    mOutputChannelCount = numOutputs;
+}
+
+void OboeEngine::getAudioParams(int &numInputs, int &numOutputs, int &sampleRate) {
+    if (!mPlayStream) return;
+    numInputs = mRecordingStream ? mRecordingStream->getChannelCount() : 0;
+    numOutputs = mPlayStream->getChannelCount();
+    sampleRate = mPlayStream->getSampleRate();
+}
+
+void OboeEngine::setAudioCallback(void (*callback)(void*), void *userData) {
+    mAudioCallback = callback;
+    mAudioCallbackUserData = userData;
+}
+
+void OboeEngine::setBufferSizeInFrames(int frames)
+{
+    mBufferSizeInFrames = frames;
+    if (mPlayStream && mBufferSizeInFrames != oboe::kUnspecified) {
+        mPlayStream->setBufferSizeInFrames(mBufferSizeInFrames);
+    }
+}
+
+void OboeEngine::setSampleRate(int srate) {
+    mRequestedSampleRate = srate;
+}
+
+bool OboeEngine::setEffectOn(bool isOn) {
+    bool success = true;
+    if (isOn != mIsEffectOn) {
+        if (isOn) {
+            success = openStreams() == oboe::Result::OK;
+            if (success) {
+                mIsEffectOn = isOn;
+            }
+        } else {
+            closeStreams();
+            mIsEffectOn = isOn;
+       }
+    }
+    return success;
+}
+
+void OboeEngine::closeStreams() {
+    /*
+    * Note: The order of events is important here.
+    * The playback stream must be closed before the recording stream. If the
+    * recording stream were to be closed first the playback stream's
+    * callback may attempt to read from the recording stream
+    * which would cause the app to crash since the recording stream would be
+    * null.
+    */
+    if (mDuplexStream) {
+        mDuplexStream->stop();
+        closeStream(mPlayStream);
+        closeStream(mRecordingStream);
+        mDuplexStream.reset();
+    } else {
+        closeStream(mPlayStream);
+        mSimplexStream.reset();
+    }
+}
+
+oboe::Result  OboeEngine::openStreams() {
+    // Note: The order of stream creation is important. We create the playback
+    // stream first, then use properties from the playback stream
+    // (e.g. sample rate) to create the recording stream. By matching the
+    // properties we should get the lowest latency path
+    mSampleRate = mRequestedSampleRate;
+    oboe::AudioStreamBuilder inBuilder, outBuilder;
+    setupPlaybackStreamParameters(&outBuilder);
+    oboe::Result result = outBuilder.openStream(mPlayStream);
+    if (result != oboe::Result::OK) {
+        LOGE("Failed to open output stream. Error %s", oboe::convertToText(result));
+        mSampleRate = oboe::kUnspecified;
+        return result;
+    } else {
+        // The input stream needs to run at the same sample rate as the output.
+        mSampleRate = mPlayStream->getSampleRate();
+        // A buffer size may have been specified:
+        if (mBufferSizeInFrames != oboe::kUnspecified) {
+            mPlayStream->setBufferSizeInFrames(mBufferSizeInFrames);
+        }
+    }
+    warnIfNotLowLatency(mPlayStream);
+
+    if (mInputChannelCount > 0) {
+        setupRecordingStreamParameters(&inBuilder, mSampleRate);
+        result = inBuilder.openStream(mRecordingStream);
+        if (result != oboe::Result::OK) {
+            LOGE("Failed to open input stream. Error %s", oboe::convertToText(result));
+        } else {
+            warnIfNotLowLatency(mRecordingStream);
+        }
+    }
+
+    if (mRecordingStream) {
+        mDuplexStream = std::make_unique<PdStreamDuplex>();
+        mDuplexStream->setSharedInputStream(mRecordingStream);
+        mDuplexStream->setSharedOutputStream(mPlayStream);
+        mDuplexStream->start();
+    } else {
+        mSimplexStream = std::make_unique<PdStreamSimplex>();
+        mPlayStream->start();
+    }
+
+    return oboe::Result::OK;
+}
+
+/**
+ * Sets the stream parameters which are specific to recording,
+ * including the sample rate which is determined from the
+ * playback stream.
+ *
+ * @param builder The recording stream builder
+ * @param sampleRate The desired sample rate of the recording stream
+ */
+oboe::AudioStreamBuilder *OboeEngine::setupRecordingStreamParameters(
+    oboe::AudioStreamBuilder *builder, int32_t sampleRate) {
+    // This sample uses blocking read() because we don't specify a callback
+    builder->setDeviceId(mRecordingDeviceId)
+        ->setDirection(oboe::Direction::Input)
+        ->setSampleRate(sampleRate)
+        ->setChannelCount(mInputChannelCount);
+    return setupCommonStreamParameters(builder);
+}
+
+/**
+ * Sets the stream parameters which are specific to playback, including device
+ * id and the dataCallback function, which must be set for low latency
+ * playback.
+ * @param builder The playback stream builder
+ */
+oboe::AudioStreamBuilder *OboeEngine::setupPlaybackStreamParameters(
+    oboe::AudioStreamBuilder *builder) {
+    builder->setDataCallback(this)
+        ->setErrorCallback(this)
+        ->setDeviceId(mPlaybackDeviceId)
+        ->setDirection(oboe::Direction::Output)
+        ->setChannelCount(mOutputChannelCount)
+        ->setSampleRate(mSampleRate);
+
+    return setupCommonStreamParameters(builder);
+}
+
+/**
+ * Set the stream parameters which are common to both recording and playback
+ * streams.
+ * @param builder The playback or recording stream builder
+ */
+oboe::AudioStreamBuilder *OboeEngine::setupCommonStreamParameters(
+    oboe::AudioStreamBuilder *builder) {
+    // We request EXCLUSIVE mode since this will give us the lowest possible
+    // latency.
+    // If EXCLUSIVE mode isn't available the builder will fall back to SHARED
+    // mode.
+    builder->setAudioApi(mAudioApi)
+        ->setFormat(mFormat)
+        ->setFormatConversionAllowed(true)
+        ->setSharingMode(oboe::SharingMode::Exclusive)
+        ->setPerformanceMode(oboe::PerformanceMode::LowLatency);
+    return builder;
+}
+
+/**
+ * Close the stream. AudioStream::close() is a blocking call so
+ * the application does not need to add synchronization between
+ * onAudioReady() function and the thread calling close().
+ * [the closing thread is the UI thread in this sample].
+ * @param stream the stream to close
+ */
+void OboeEngine::closeStream(std::shared_ptr<oboe::AudioStream> &stream) {
+    if (stream) {
+        oboe::Result result = stream->stop();
+        if (result != oboe::Result::OK) {
+            LOGW("Error stopping stream: %s", oboe::convertToText(result));
+        }
+        result = stream->close();
+        if (result != oboe::Result::OK) {
+            LOGE("Error closing stream: %s", oboe::convertToText(result));
+        } else {
+            LOGW("Successfully closed streams");
+        }
+        stream.reset();
+    }
+}
+
+/**
+ * Warn in logcat if non-low latency stream is created
+ * @param stream: newly created stream
+ *
+ */
+void OboeEngine::warnIfNotLowLatency(std::shared_ptr<oboe::AudioStream> &stream) {
+    if (stream->getPerformanceMode() != oboe::PerformanceMode::LowLatency) {
+        LOGW(
+            "Stream is NOT low latency."
+            "Check your requested format, sample rate and channel count");
+    }
+}
+
+/**
+ * Handles playback stream's audio request. In this sample, we simply block-read
+ * from the record stream for the required samples.
+ *
+ * @param oboeStream: the playback stream that requesting additional samples
+ * @param audioData:  the buffer to load audio samples for playback stream
+ * @param numFrames:  number of frames to load to audioData buffer
+ * @return: DataCallbackResult::Continue.
+ */
+oboe::DataCallbackResult OboeEngine::onAudioReady(
+    oboe::AudioStream *oboeStream, void *audioData, int32_t numFrames) {
+    if (mAudioCallback) {
+        mAudioCallback(mAudioCallbackUserData);
+    }
+    if (mDuplexStream) {
+        return mDuplexStream->onAudioReady(oboeStream, audioData, numFrames);
+    } else if (mSimplexStream) {
+        return mSimplexStream->onAudioReady(oboeStream, audioData, numFrames);
+    }
+    return oboe::DataCallbackResult::Stop;
+}
+
+/**
+ * Oboe notifies the application for "about to close the stream".
+ *
+ * @param oboeStream: the stream to close
+ * @param error: oboe's reason for closing the stream
+ */
+void OboeEngine::onErrorBeforeClose(oboe::AudioStream *oboeStream,
+                                          oboe::Result error) {
+    LOGE("%s stream Error before close: %s",
+         oboe::convertToText(oboeStream->getDirection()),
+         oboe::convertToText(error));
+}
+
+/**
+ * Oboe notifies application that "the stream is closed"
+ *
+ * @param oboeStream
+ * @param error
+ */
+void OboeEngine::onErrorAfterClose(oboe::AudioStream *oboeStream,
+                                         oboe::Result error) {
+    LOGE("%s stream Error after close: %s",
+         oboe::convertToText(oboeStream->getDirection()),
+         oboe::convertToText(error));
+
+    closeStreams();
+
+    // Restart the stream if the error is a disconnect.
+    if (error == oboe::Result::ErrorDisconnected) {
+        LOGI("Restarting AudioStream");
+        openStreams();
+    }
+}

--- a/jni/oboe/OboeEngine.h
+++ b/jni/oboe/OboeEngine.h
@@ -1,0 +1,87 @@
+/*
+ * Copyright (c) 2025 Antoine Rousseau
+ * (derived from 'LiveEffect' oboe sample)
+ *
+ * For information on usage and redistribution, and for a DISCLAIMER OF ALL
+ * WARRANTIES, see the file, "LICENSE.txt," in this distribution.
+ */
+
+#ifndef OBOE_ENGINE_H
+#define OBOE_ENGINE_H
+
+#include <jni.h>
+#include <oboe/Oboe.h>
+#include <string>
+#include <thread>
+#include "PdStreams.h"
+
+class OboeEngine : public oboe::AudioStreamCallback {
+public:
+    OboeEngine();
+
+    void setRecordingDeviceId(int32_t deviceId);
+    void setPlaybackDeviceId(int32_t deviceId);
+    bool setAudioApi(oboe::AudioApi);
+    bool isAAudioRecommended(void);
+    void setChannelCounts(int numInputs, int numOutputs);
+    void getAudioParams(int &numInputs, int &numOutputs, int &sampleRate);
+    void setBufferSizeInFrames(int frames);
+    void setSampleRate(int srate);
+
+    /* optional user audio callback */
+    void setAudioCallback(void (*callback)(void*), void *userData = nullptr);
+
+    /**
+     * @param isOn
+     * @return true if it succeeds
+     */
+    bool setEffectOn(bool isOn);
+
+    /*
+     * oboe::AudioStreamDataCallback interface implementation
+     */
+    oboe::DataCallbackResult onAudioReady(oboe::AudioStream *oboeStream,
+                                          void *audioData, int32_t numFrames) override;
+
+    /*
+     * oboe::AudioStreamErrorCallback interface implementation
+     */
+    void onErrorBeforeClose(oboe::AudioStream *oboeStream, oboe::Result error) override;
+    void onErrorAfterClose(oboe::AudioStream *oboeStream, oboe::Result error) override;
+
+private:
+    bool mIsEffectOn = false;
+    int32_t mRecordingDeviceId = oboe::kUnspecified;
+    int32_t mPlaybackDeviceId = oboe::kUnspecified;
+    const oboe::AudioFormat mFormat = oboe::AudioFormat::Float; // for easier processing
+    oboe::AudioApi mAudioApi = oboe::AudioApi::AAudio;
+    int32_t mSampleRate = oboe::kUnspecified;
+    int32_t mRequestedSampleRate = oboe::kUnspecified;
+    int32_t mBufferSizeInFrames = oboe::kUnspecified;
+    int32_t mInputChannelCount = oboe::ChannelCount::Stereo;
+    int32_t mOutputChannelCount = oboe::ChannelCount::Stereo;
+
+    std::unique_ptr<PdStreamDuplex> mDuplexStream;
+    std::unique_ptr<PdStreamSimplex> mSimplexStream;
+    std::shared_ptr<oboe::AudioStream> mRecordingStream;
+    std::shared_ptr<oboe::AudioStream> mPlayStream;
+
+    void (*mAudioCallback)(void *data) = nullptr;
+    void *mAudioCallbackUserData = nullptr;
+
+    oboe::Result openStreams();
+
+    void closeStreams();
+
+    void closeStream(std::shared_ptr<oboe::AudioStream> &stream);
+
+    oboe::AudioStreamBuilder *setupCommonStreamParameters(
+        oboe::AudioStreamBuilder *builder);
+    oboe::AudioStreamBuilder *setupRecordingStreamParameters(
+        oboe::AudioStreamBuilder *builder, int32_t sampleRate);
+    oboe::AudioStreamBuilder *setupPlaybackStreamParameters(
+        oboe::AudioStreamBuilder *builder);
+    void warnIfNotLowLatency(std::shared_ptr<oboe::AudioStream> &stream);
+};
+
+#endif  // OBOE_ENGINE_H

--- a/jni/oboe/OboeEngine.h
+++ b/jni/oboe/OboeEngine.h
@@ -13,6 +13,8 @@
 #include <oboe/Oboe.h>
 #include <string>
 #include <thread>
+#include <atomic>
+
 #include "PdStreams.h"
 
 class OboeEngine : public oboe::AudioStreamCallback {
@@ -27,6 +29,8 @@ public:
     void getAudioParams(int &numInputs, int &numOutputs, int &sampleRate);
     void setBufferSizeInFrames(int frames);
     void setSampleRate(int srate);
+    int getLatencyMillis();
+    int getXRuns();
 
     /* optional user audio callback */
     void setAudioCallback(void (*callback)(void*), void *userData = nullptr);
@@ -60,6 +64,8 @@ private:
     int32_t mBufferSizeInFrames = oboe::kUnspecified;
     int32_t mInputChannelCount = oboe::ChannelCount::Stereo;
     int32_t mOutputChannelCount = oboe::ChannelCount::Stereo;
+    std::atomic<int> mCalculatedLatencyMillis = 0;
+    std::atomic<int> mXRuns = 0;
 
     std::unique_ptr<PdStreamDuplex> mDuplexStream;
     std::unique_ptr<PdStreamSimplex> mSimplexStream;

--- a/jni/oboe/PdStreams.h
+++ b/jni/oboe/PdStreams.h
@@ -1,0 +1,175 @@
+/*
+ * Copyright (c) 2025 Antoine Rousseau
+ *
+ * For information on usage and redistribution, and for a DISCLAIMER OF ALL
+ * WARRANTIES, see the file, "LICENSE.txt," in this distribution.
+ */
+
+#pragma once
+
+#include "z_libpd.h"
+
+extern "C" {
+    pthread_mutex_t *jni_oboe_get_libpd_mutex();
+}
+
+class PdStreamDuplex : public oboe::FullDuplexStream {
+private:
+    static const int MAX_NFRAMES = 8192;
+    static const int MAX_IN_CHANS = 8;
+    static const int MAX_OUT_CHANS = 8;
+    static const int PD_BLOCKSIZE = 64;
+    pthread_mutex_t &mutex = *jni_oboe_get_libpd_mutex();
+
+    class InputBuffer {
+    private:
+        static const int BUFSIZE = MAX_NFRAMES * MAX_IN_CHANS;
+        float ringbuffer[BUFSIZE];
+        float blockbuffer[PD_BLOCKSIZE * MAX_IN_CHANS];
+        int queue = 0;
+        int tail = 0;
+    public:
+        bool is_empty() {
+            return queue == tail;
+        }
+        bool is_full() {
+            return ((tail + 1) % BUFSIZE) == queue;
+        }
+        void push(const float *samples, int nsamples) {
+            for(int c = 0; c < nsamples; c++) {
+                if(is_full()) break;
+                ringbuffer[tail++] = samples[c];
+                if(tail == BUFSIZE)
+                    tail = 0;
+            }
+        }
+        float *pop_block(int nchannels) {
+            int nsamples = PD_BLOCKSIZE * nchannels;
+            for(int i = 0 ; i < nsamples; i++) {
+                float s = 0.0;
+                if(!is_empty()) {
+                    s = ringbuffer[queue++];
+                    if(queue == BUFSIZE)
+                        queue = 0;
+                }
+                blockbuffer[i] = s;
+            }
+            return blockbuffer;
+        }
+    } inputBuffer;
+
+    class OutputBuffer {
+    private:
+        float buffer[PD_BLOCKSIZE * MAX_OUT_CHANS];
+        int len = 0;
+        int index = 0;
+    public:
+        bool is_empty() {
+            return index == len;
+        }
+        float *init(int nsamples) {
+            len = nsamples;
+            index = 0;
+            return buffer;
+        }
+        float pop() {
+            return buffer[index++];
+        }
+    } outputBuffer;
+
+public:
+    virtual oboe::DataCallbackResult onBothStreamsReady(
+            const void *inputData,
+            int   numInputFrames,
+            void *outputData,
+            int   numOutputFrames) {
+
+        // This code assumes the data format for both streams is Float.
+        const float *inputFloats = static_cast<const float *>(inputData);
+        float *outputFloats = static_cast<float *>(outputData);
+
+        int32_t inChannels = getInputStream()->getChannelCount();
+        int32_t outChannels = getOutputStream()->getChannelCount();
+        int32_t numInputSamples = numInputFrames * inChannels;
+        int32_t numOutputSamples = numOutputFrames * outChannels;
+
+        // Store input samples in inputBuffer ring buffer
+        if(numInputSamples < MAX_NFRAMES) // ignore too big buffers
+            inputBuffer.push(inputFloats, numInputSamples);
+
+        int processedSamples = 0;
+        while(processedSamples < numOutputSamples) {
+            // If outputBuffer is empty, get a new one from Pd in exchange for a block from inputBuffer.
+            // When inputBuffer doesn't have enough data, it fills the block with zeroes.
+            if(outputBuffer.is_empty()) {
+                pthread_mutex_lock(&mutex);
+                libpd_process_float(1,
+                    inputBuffer.pop_block(inChannels),
+                    outputBuffer.init(PD_BLOCKSIZE * outChannels)
+                );
+                pthread_mutex_unlock(&mutex);
+            }
+            // Send next outputBuffer sample to audio output
+            outputFloats[processedSamples++] = outputBuffer.pop();
+        }
+
+        return oboe::DataCallbackResult::Continue;
+    }
+};
+
+class PdStreamSimplex {
+private:
+    static const int MAX_NFRAMES = 8192;
+    static const int MAX_OUT_CHANS = 8;
+    static const int PD_BLOCKSIZE = 64;
+    pthread_mutex_t &mutex = *jni_oboe_get_libpd_mutex();
+
+    class OutputBuffer {
+    private:
+        float buffer[PD_BLOCKSIZE * MAX_OUT_CHANS];
+        int len = 0;
+        int index = 0;
+    public:
+        bool is_empty() {
+            return index == len;
+        }
+        float *init(int nsamples) {
+            len = nsamples;
+            index = 0;
+            return buffer;
+        }
+        float pop() {
+            return buffer[index++];
+        }
+    } outputBuffer;
+
+public:
+    oboe::DataCallbackResult onAudioReady(
+            oboe::AudioStream *oboeStream,
+            void *outputData,
+            int   numOutputFrames) {
+
+        float *outputFloats = static_cast<float *>(outputData);
+
+        int32_t outChannels = oboeStream->getChannelCount();
+        int32_t numOutputSamples = numOutputFrames * outChannels;
+        int processedSamples = 0;
+        while(processedSamples < numOutputSamples) {
+            // If outputBuffer is empty, get a new one from Pd.
+            if(outputBuffer.is_empty()) {
+                float dummy;
+                pthread_mutex_lock(&mutex);
+                libpd_process_float(1,
+                    &dummy,
+                    outputBuffer.init(PD_BLOCKSIZE * outChannels)
+                );
+                pthread_mutex_unlock(&mutex);
+            }
+            // Send next outputBuffer sample to audio output
+            outputFloats[processedSamples++] = outputBuffer.pop();
+        }
+
+        return oboe::DataCallbackResult::Continue;
+    }
+};
+

--- a/jni/oboe/logging_macros.h
+++ b/jni/oboe/logging_macros.h
@@ -1,0 +1,46 @@
+/*
+ * Copyright (C) 2017 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+#ifndef __SAMPLE_ANDROID_DEBUG_H__
+#define __SAMPLE_ANDROID_DEBUG_H__
+#include <android/log.h>
+
+#if 1
+#ifndef MODULE_NAME
+#define MODULE_NAME  "AUDIO-APP"
+#endif
+
+#define LOGV(...) __android_log_print(ANDROID_LOG_VERBOSE, MODULE_NAME, __VA_ARGS__)
+#define LOGD(...) __android_log_print(ANDROID_LOG_DEBUG, MODULE_NAME, __VA_ARGS__)
+#define LOGI(...) __android_log_print(ANDROID_LOG_INFO, MODULE_NAME, __VA_ARGS__)
+#define LOGW(...) __android_log_print(ANDROID_LOG_WARN,MODULE_NAME, __VA_ARGS__)
+#define LOGE(...) __android_log_print(ANDROID_LOG_ERROR,MODULE_NAME, __VA_ARGS__)
+#define LOGF(...) __android_log_print(ANDROID_LOG_FATAL,MODULE_NAME, __VA_ARGS__)
+
+#define ASSERT(cond, ...) if (!(cond)) {__android_log_assert(#cond, MODULE_NAME, __VA_ARGS__);}
+#else
+
+#define LOGV(...)
+#define LOGD(...)
+#define LOGI(...)
+#define LOGW(...)
+#define LOGE(...)
+#define LOGF(...)
+#define ASSERT(cond, ...)
+
+#endif
+
+#endif // __SAMPLE_ANDROID_DEBUG_H__

--- a/jni/oboe/z_jni_oboe.cpp
+++ b/jni/oboe/z_jni_oboe.cpp
@@ -1,0 +1,133 @@
+/*
+ * Copyright (c) 2025 Antoine Rousseau
+ *
+ * For information on usage and redistribution, and for a DISCLAIMER OF ALL
+ * WARRANTIES, see the file, "LICENSE.txt," in this distribution.
+ */
+
+#include "logging_macros.h"
+#include "z_jni_oboe.h"
+
+static OboeEngine *engine = nullptr;
+static bool isRunning = false;
+
+pthread_mutex_t &mutex = *jni_oboe_get_libpd_mutex();
+
+OboeEngine *jni_oboe_get_engine() {
+    return engine;
+}
+
+extern "C" {
+
+JNIEXPORT jstring JNICALL Java_org_puredata_core_PdBase_audioImplementation
+(JNIEnv *env , jclass cls) {
+    return env->NewStringUTF("Oboe");
+}
+
+JNIEXPORT jboolean JNICALL Java_org_puredata_core_PdBase_implementsAudio
+(JNIEnv *env, jclass cls) {
+    return JNI_TRUE;
+}
+
+JNIEXPORT void JNICALL Java_org_puredata_core_PdBase_closeAudio
+(JNIEnv *env, jclass cls) {
+    if (engine) {
+        engine->setEffectOn(false);
+        isRunning = false;
+        delete engine;
+        engine = nullptr;
+    }
+}
+
+void options_callback(const char* key, const char *value) {
+    if (!strcmp(key, "inputDeviceId")) {
+        int id = atoi(value);
+        engine->setRecordingDeviceId(id < 0 ? oboe::kUnspecified : id);
+    } else if (!strcmp(key, "outputDeviceId")) {
+        int id = atoi(value);
+        engine->setPlaybackDeviceId(id < 0 ? oboe::kUnspecified : id);
+    } else if (!strcmp(key, "bufferSizeInFrames")) {
+        int size = atoi(value);
+        engine->setBufferSizeInFrames(size < 0 ? oboe::kUnspecified : size);
+    }
+}
+
+JNIEXPORT jint JNICALL Java_org_puredata_core_PdBase_openAudio
+(JNIEnv *env, jclass cls, jint inChans, jint outChans, jint sRate,
+jobject options) {
+    Java_org_puredata_core_PdBase_closeAudio(env, cls);
+    pthread_mutex_lock(&mutex);
+    // Pd audio parameters will be updated later, in startAudio
+    jint err = libpd_init_audio(2, 2, 48000);
+    pthread_mutex_unlock(&mutex);
+    if (err) return err;
+    if (engine == nullptr) {
+        engine = new OboeEngine();
+    }
+    if (engine != nullptr) {
+        LOGV("requested sample rate %d", sRate);
+        engine->setSampleRate(sRate < 0 ? oboe::kUnspecified : sRate);
+        engine->setAudioApi(engine->isAAudioRecommended() ? oboe::AudioApi::AAudio : oboe::AudioApi::OpenSLES);
+        engine->setChannelCounts(
+            inChans < 0 ? oboe::kUnspecified : inChans,
+            outChans < 0 ? oboe::kUnspecified : outChans
+        );
+        map_foreach(env, options, options_callback);
+    }
+    return (engine == nullptr) ? -1 : 0;
+}
+
+JNIEXPORT jint JNICALL Java_org_puredata_core_PdBase_startAudio
+(JNIEnv *env, jclass cls) {
+    if (engine == nullptr) {
+        LOGE(
+            "Engine is null, you must call createEngine before calling startAudio "
+            "method");
+        return -1;
+    }
+    isRunning = engine->setEffectOn(true);
+    // update Pd audio parameters for the actual devices
+    if (isRunning) {
+        int inChans, outChans, sRate;
+        engine->getAudioParams(inChans, outChans, sRate);
+        libpd_init_audio(inChans, outChans, sRate);
+        LOGV("final sample rate %d", sRate);
+    }
+    return isRunning ? 0 : -1;
+}
+
+JNIEXPORT jint JNICALL Java_org_puredata_core_PdBase_pauseAudio
+(JNIEnv *env, jclass cls) {
+    if (engine == nullptr) {
+        LOGE(
+            "Engine is null, you must call createEngine before calling pauseAudio "
+            "method");
+        return -1;
+    }
+    isRunning = false;
+    engine->setEffectOn(false);
+    return 0;
+}
+
+JNIEXPORT jboolean JNICALL Java_org_puredata_core_PdBase_isRunning
+(JNIEnv *env, jclass cls) {
+  return engine && isRunning;
+}
+
+JNIEXPORT jint JNICALL Java_org_puredata_core_PdBase_suggestSampleRate
+(JNIEnv *env, jclass cls) {
+  return -1;
+}
+
+JNIEXPORT jint JNICALL Java_org_puredata_core_PdBase_suggestInputChannels
+(JNIEnv *env, jclass cls) {
+  return -1;
+}
+
+JNIEXPORT jint JNICALL Java_org_puredata_core_PdBase_suggestOutputChannels
+(JNIEnv *env, jclass cls) {
+  return -1;
+}
+
+} // extern "C"
+

--- a/jni/oboe/z_jni_oboe.h
+++ b/jni/oboe/z_jni_oboe.h
@@ -1,0 +1,14 @@
+/*
+ * Copyright (c) 2025 Antoine Rousseau
+ *
+ * For information on usage and redistribution, and for a DISCLAIMER OF ALL
+ * WARRANTIES, see the file, "LICENSE.txt," in this distribution.
+ */
+
+#pragma once
+
+#include "OboeEngine.h"
+#include "z_jni_utils.h"
+
+OboeEngine *jni_oboe_get_engine();
+

--- a/jni/oboe/z_jni_oboe_shared.c
+++ b/jni/oboe/z_jni_oboe_shared.c
@@ -1,0 +1,7 @@
+
+#include "z_jni_shared.c"
+
+// export mutex to C++
+pthread_mutex_t *jni_oboe_get_libpd_mutex() {
+    return &mutex;
+}

--- a/jni/z_jni.h
+++ b/jni/z_jni.h
@@ -57,6 +57,14 @@ JNIEXPORT jint JNICALL Java_org_puredata_core_PdBase_openAudio
 
 /*
  * Class:     org_puredata_core_PdBase
+ * Method:    audioRuntimeInfo
+ * Signature: (Ljava/lang/String;)Ljava/lang/String;
+ */
+JNIEXPORT jstring JNICALL Java_org_puredata_core_PdBase_audioRuntimeInfo
+  (JNIEnv *, jclass, jstring);
+
+/*
+ * Class:     org_puredata_core_PdBase
  * Method:    implementsAudio
  * Signature: ()Z
  */

--- a/jni/z_jni_shared.c
+++ b/jni/z_jni_shared.c
@@ -7,6 +7,7 @@
 
 #include "z_jni.h"
 #include "z_jni_native_hooks.h"
+#include "z_jni_utils.h"
 
 #include <pthread.h>
 #include <stdio.h>
@@ -74,6 +75,79 @@ static jobjectArray makeJavaArray(JNIEnv *env, int argc, t_atom *argv) {
     }
   }
   return jarray;
+}
+
+// Gets all key/value pairs from a java HashMap<String, String>,
+// and call a user function for each.
+// (thanks to https://github.com/mkowsiak/jnicookbook/blob/master/recipes/recipeNo037)
+void map_foreach(JNIEnv *env, jobject map, foreach_callback_t callback) {
+  jclass clsHashMap = (*env)->GetObjectClass (env, map);
+
+  // Retreive Set.keySet() method id.
+  // Descriptor obtained with:
+  // javap -s -p java.util.HashMap | grep -A 1 keySet
+  jmethodID midKeySet =
+    (*env)->GetMethodID (env, clsHashMap, "keySet", "()Ljava/util/Set;");
+
+  // Make sure that method exists
+  if (midKeySet == NULL) {
+    return; // method not found
+  }
+
+  // Get Set of keys
+  jobject objKeySet = (*env)->CallObjectMethod (env, map, midKeySet);
+  jclass clsSet = (*env)->GetObjectClass (env, objKeySet);
+
+  // Retreive Set.toArray() method id.
+  // Descriptor obtained with:
+  // javap -s -p java.util.Set | grep -A 1 toArray
+  jmethodID midToArray =
+    (*env)->GetMethodID (env, clsSet, "toArray", "()[Ljava/lang/Object;");
+
+  // Make sure that method exists
+  if (midToArray == NULL) {
+    return; // method not found
+  }
+
+  // Get array of all keys
+  jobjectArray arrayOfKeys =
+    (*env)->CallObjectMethod (env, objKeySet, midToArray);
+  int arraySize = (*env)->GetArrayLength (env, arrayOfKeys);
+
+  // Iterate over key indexes
+  for (int i = 0; i < arraySize; i++) {
+    // First, we need to get key from array of all keys
+    jstring objKey = (*env)->GetObjectArrayElement (env, arrayOfKeys, i);
+    const char *c_string_key = (*env)->GetStringUTFChars (env, objKey, 0);
+
+    // Once we have key, we can retrieve value for that key
+    jmethodID midGet =
+      (*env)->GetMethodID ( env,
+        clsHashMap,
+        "get",
+        "(Ljava/lang/Object;)Ljava/lang/Object;");
+
+    // Make sure that method exists
+    if (midGet == NULL) {
+      return; // method not found
+    }
+
+    // Get Value for Key
+    jobject objValue = (*env)->CallObjectMethod (env, map, midGet, objKey);
+    const char *c_string_value = (*env)->GetStringUTFChars (env, objValue, 0);
+
+    // Call the callback
+    if (callback) {
+      callback(c_string_key, c_string_value);
+    }
+
+    // Release local stuff */
+    (*env)->ReleaseStringUTFChars (env, objKey, c_string_key);
+    (*env)->DeleteLocalRef (env, objKey);
+
+    (*env)->ReleaseStringUTFChars (env, objValue, c_string_value);
+    (*env)->DeleteLocalRef (env, objValue);
+  }
 }
 
 static void java_printhook(const char *msg) {

--- a/jni/z_jni_shared.c
+++ b/jni/z_jni_shared.c
@@ -711,6 +711,12 @@ JNIEXPORT jstring JNICALL Java_org_puredata_core_PdBase_versionString
   return result;
 }
 
+__attribute__((weak))
+JNIEXPORT jstring JNICALL Java_org_puredata_core_PdBase_audioRuntimeInfo
+ (JNIEnv *env, jclass cls, jstring key) {
+    return (*env)->NewStringUTF(env, "unknown");
+}
+
 // -----------------------------------------------------------------------------
 // Audio glue needs to be supplied in another file.
 // -----------------------------------------------------------------------------

--- a/jni/z_jni_utils.h
+++ b/jni/z_jni_utils.h
@@ -1,0 +1,23 @@
+/*
+ * Java-native interface utilities
+ */
+
+#ifndef _Z_JNI_UTILS_H
+#define _Z_JNI_UTILS_H
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#include <jni.h>
+
+// key/value callback type
+typedef void(*foreach_callback_t)(const char* key, const char *value);
+
+// Gets all key/value pairs from a java HashMap<String, String>,
+// and call a user function for each.
+void map_foreach(JNIEnv *env, jobject map, foreach_callback_t callback);
+
+#ifdef __cplusplus
+}
+#endif
+#endif


### PR DESCRIPTION
This implements the native interface for the Oboe audio driver library.

It takes care of the buffer size conversion between Pd and Oboe, separately for input and output (since Oboe can provide less input samples than output ones, mainly on start).

The new `pdnativeoboe.so` is now loaded by PdBase loader when on Android, replacing the previous `pdnativeopensl.so`.

Closes #284.

This PR is similar to #422, but involves less change in the Java API.
